### PR TITLE
Add initial support for draft 7

### DIFF
--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -31,6 +31,9 @@ function generateMarkdown(options) {
         else if (schemaRef === 'http://json-schema.org/draft-04/schema') {
             resolved = schema4.resolve(schema, options.fileName, options.searchPath, options.ignorableTypes, options.debug);
         }
+        else if (schemaRef === 'http://json-schema.org/draft-07/schema#') {
+            resolved = schema4.resolve(schema, options.fileName, options.searchPath, options.ignorableTypes, options.debug);
+        }
         else {
             resolved = schema3.resolve(schema, options.fileName, options.searchPath, options.ignorableTypes, options.debug);
             if (!options.suppressWarnings) {


### PR DESCRIPTION
This just allows wetzel to read draft 7 schemas instead of falling back to version 3. Draft 7 is not very different from 4 so it will work for most cases.