### PR TITLE
Add a "section description" block.

### DIFF
--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -153,6 +153,12 @@ function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, sche
         md += value + '\n\n';
     }
 
+    // TODO: Add plugin point for custom JSON schema properties like gltf_*
+    var extendedDescription = schema.gltf_sectionDescription;
+    if (defined(extendedDescription)) {
+        md += autoLinkDescription(extendedDescription, knownTypes, autoLink) + '\n\n';
+    }
+
     // Render type
     var schemaType = schema.type;
     if (defined(schemaType)) {


### PR DESCRIPTION
This fixes an issue where we want to attach a note to `extras`, but not have the note duplicated throughout the reference section for each instance of `extras`.