### PR TITLE
Add tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,8 @@
     "rules": {
         "quotes": ["off", "single", { "avoidEscape": true }],
         "guard-for-in": ["off"],
+        "semi": 1,
+        "no-extra-semi": 1,
         "no-prototype-builtins": "off",
         "no-useless-escape": "off"
     }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Workaround for https://github.com/npm/npm/issues/17161
 package*.json text eol=lf
+
+# Golden files
+test/test-golden/* text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .DS_Store
 Thumbs.db
 .vscode/*
+
+# Ignore generated test outputs
+test/test-output

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ is used to generate this Markdown documentation:
 
 Example description.
 
-**Properties**
+**`example` Properties**
 
 |   |Type|Description|Required|
-|---|----|-----------|--------|
+|---|---|---|---|
 |**byteOffset**|`integer`|The offset relative to the start of the buffer in bytes.|No, default: `0`|
 |**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &#x2705; Yes|
 
@@ -63,7 +63,7 @@ The offset relative to the start of the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: ` >= 0`
 
-### example.type &#x2705;
+### example.type &#x2705; 
 
 Specifies if the elements are scalars, vectors, or matrices.
 
@@ -105,6 +105,8 @@ wetzel.js ../glTF/specification/2.0/schema/accessor.schema.json -l 2 | clip
 Options:
 * The `-l` option specifies the starting header level.
 * The `-p` option lets you specify the relative path that should be used when referencing the schema, relative to where you store the documentation.
+* The `-s` option lets you specify the path string that should be used when loading the schema reference paths.
+* The `-m` option controls the output style mode. The default is `Markdown`, use `-m=a` for `AsciiDoctor` mode.
 * The `-w` option will suppress any warnings about potential documentation problems that wetzel normally prints by default.
 * The `-d` option lets you specify the root filename that will be used for writing intermediate wetzel artifacts that are useful when doing wetzel development.
 * The `-a` option will attempt to aggressively auto-link referenced type names in descriptions between each other.  If it's too agressive, you can add `=cqo` so that it only attempts to auto-link type names that are within "code-quotes only" (cqo) (e.g.: ``typeName``)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ On Windows:
 wetzel.js ../glTF/specification/2.0/schema/accessor.schema.json -l 2 | clip
 ```
 
+Run the tests:
+```
+npm run test
+```
+
 Options:
 * The `-l` option specifies the starting header level.
 * The `-p` option lets you specify the relative path that should be used when referencing the schema, relative to where you store the documentation.

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -1,5 +1,4 @@
 "use strict";
-var path = require('path');
 var defined = require('./defined');
 var defaultValue = require('./defaultValue');
 var sortObject = require('./sortObject');
@@ -189,7 +188,10 @@ function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, sche
 
         // Schema reference
         if (defined(schemaRelativeBasePath)) {
-            md += style.bulletItem(style.bold('JSON schema') + ': ' + style.getLinkMarkdown(fileName, path.join(schemaRelativeBasePath, fileName).replace(/\\/g, '/'))) + '\n';
+            if (!schemaRelativeBasePath.endsWith('/')) {
+                schemaRelativeBasePath += '/';
+            }
+            md += style.bulletItem(style.bold('JSON schema') + ': ' + style.getLinkMarkdown(fileName, schemaRelativeBasePath.replace(/\\/g, '/') + fileName)) + '\n';
 
             // TODO: figure out how to auto-determine example reference
             //* **Example**: [bufferViews.json](schema/examples/bufferViews.json)

--- a/package.json
+++ b/package.json
@@ -30,9 +30,14 @@
         "minimist": "1.1.0"
     },
     "devDependencies": {
-        "eslint": "^7.10.0"
+        "eslint": "^7.10.0",
+        "mocha": "^8.2.1"
     },
     "bin": {
         "wetzel": "./bin/wetzel.js"
+    },
+    "scripts": {
+        "test": "mocha",
+        "test-bail": "mocha -b"
     }
 }

--- a/test/test-golden/example-linked.adoc
+++ b/test/test-golden/example-linked.adoc
@@ -1,0 +1,54 @@
+== Objects
+* link:#reference-example[`example`] (root object)
+
+
+'''
+[#reference-example]
+=== example
+
+Example description.
+
+.`example` Properties
+|===
+|   |Type|Description|Required
+
+|**byteOffset**
+|`integer`
+|The offset relative to the start of the buffer in bytes.
+|No, default: `0`
+
+|**type**
+|`string`
+|Specifies if the elements are scalars, vectors, or matrices.
+| &#x2705; Yes
+
+|===
+
+Additional properties are not allowed.
+
+* **JSON schema**: link:schema/example.schema.json[example.schema.json]
+
+==== example.byteOffset
+
+The offset relative to the start of the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+==== example.type &#x2705; 
+
+Specifies if the elements are scalars, vectors, or matrices.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+** `"SCALAR"`
+** `"VEC2"`
+** `"VEC3"`
+** `"VEC4"`
+** `"MAT2"`
+** `"MAT3"`
+** `"MAT4"`
+
+

--- a/test/test-golden/example-linked.md
+++ b/test/test-golden/example-linked.md
@@ -1,0 +1,45 @@
+## Objects
+* [`example`](#reference-example) (root object)
+
+
+---------------------------------------
+<a name="reference-example"></a>
+### example
+
+Example description.
+
+**`example` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**byteOffset**|`integer`|The offset relative to the start of the buffer in bytes.|No, default: `0`|
+|**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &#x2705; Yes|
+
+Additional properties are not allowed.
+
+* **JSON schema**: [example.schema.json](schema/example.schema.json)
+
+#### example.byteOffset
+
+The offset relative to the start of the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### example.type &#x2705; 
+
+Specifies if the elements are scalars, vectors, or matrices.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+   * `"SCALAR"`
+   * `"VEC2"`
+   * `"VEC3"`
+   * `"VEC4"`
+   * `"MAT2"`
+   * `"MAT3"`
+   * `"MAT4"`
+
+

--- a/test/test-golden/example-remote.adoc
+++ b/test/test-golden/example-remote.adoc
@@ -1,0 +1,54 @@
+== Objects
+* link:#reference-example[`example`] (root object)
+
+
+'''
+[#reference-example]
+=== example
+
+Example description.
+
+.`example` Properties
+|===
+|   |Type|Description|Required
+
+|**byteOffset**
+|`integer`
+|The offset relative to the start of the buffer in bytes.
+|No, default: `0`
+
+|**type**
+|`string`
+|Specifies if the elements are scalars, vectors, or matrices.
+| &#x2705; Yes
+
+|===
+
+Additional properties are not allowed.
+
+* **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/example.schema.json[example.schema.json]
+
+==== example.byteOffset
+
+The offset relative to the start of the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+==== example.type &#x2705; 
+
+Specifies if the elements are scalars, vectors, or matrices.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+** `"SCALAR"`
+** `"VEC2"`
+** `"VEC3"`
+** `"VEC4"`
+** `"MAT2"`
+** `"MAT3"`
+** `"MAT4"`
+
+

--- a/test/test-golden/example-remote.md
+++ b/test/test-golden/example-remote.md
@@ -1,0 +1,45 @@
+## Objects
+* [`example`](#reference-example) (root object)
+
+
+---------------------------------------
+<a name="reference-example"></a>
+### example
+
+Example description.
+
+**`example` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**byteOffset**|`integer`|The offset relative to the start of the buffer in bytes.|No, default: `0`|
+|**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &#x2705; Yes|
+
+Additional properties are not allowed.
+
+* **JSON schema**: [example.schema.json](https://www.khronos.org/wetzel/just/testing/schema/example.schema.json)
+
+#### example.byteOffset
+
+The offset relative to the start of the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### example.type &#x2705; 
+
+Specifies if the elements are scalars, vectors, or matrices.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+   * `"SCALAR"`
+   * `"VEC2"`
+   * `"VEC3"`
+   * `"VEC4"`
+   * `"MAT2"`
+   * `"MAT3"`
+   * `"MAT4"`
+
+

--- a/test/test-golden/example-simple.adoc
+++ b/test/test-golden/example-simple.adoc
@@ -1,0 +1,52 @@
+= Objects
+* link:#reference-example[`example`] (root object)
+
+
+'''
+[#reference-example]
+== example
+
+Example description.
+
+.`example` Properties
+|===
+|   |Type|Description|Required
+
+|**byteOffset**
+|`integer`
+|The offset relative to the start of the buffer in bytes.
+|No, default: `0`
+
+|**type**
+|`string`
+|Specifies if the elements are scalars, vectors, or matrices.
+| &#x2705; Yes
+
+|===
+
+Additional properties are not allowed.
+
+=== example.byteOffset
+
+The offset relative to the start of the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+=== example.type &#x2705; 
+
+Specifies if the elements are scalars, vectors, or matrices.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+** `"SCALAR"`
+** `"VEC2"`
+** `"VEC3"`
+** `"VEC4"`
+** `"MAT2"`
+** `"MAT3"`
+** `"MAT4"`
+
+

--- a/test/test-golden/example-simple.md
+++ b/test/test-golden/example-simple.md
@@ -1,0 +1,43 @@
+# Objects
+* [`example`](#reference-example) (root object)
+
+
+---------------------------------------
+<a name="reference-example"></a>
+## example
+
+Example description.
+
+**`example` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**byteOffset**|`integer`|The offset relative to the start of the buffer in bytes.|No, default: `0`|
+|**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &#x2705; Yes|
+
+Additional properties are not allowed.
+
+### example.byteOffset
+
+The offset relative to the start of the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+### example.type &#x2705; 
+
+Specifies if the elements are scalars, vectors, or matrices.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+   * `"SCALAR"`
+   * `"VEC2"`
+   * `"VEC3"`
+   * `"VEC4"`
+   * `"MAT2"`
+   * `"MAT3"`
+   * `"MAT4"`
+
+

--- a/test/test-golden/nested-linked.adoc
+++ b/test/test-golden/nested-linked.adoc
@@ -169,6 +169,11 @@ Image data used to create a texture. Image can be referenced by URI or `bufferVi
 |The index of the bufferView that contains the image. Use this instead of the image's uri property.
 |No
 
+|**fraction**
+|`number`
+|A number that must be between zero and one.
+|No
+
 |**name**
 |`string`
 |The user-defined name of this object.
@@ -215,6 +220,15 @@ The index of the bufferView that contains the image. Use this instead of the ima
 * **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
+
+==== image.fraction
+
+A number that must be between zero and one.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+* **Maximum**: ` < 1`
 
 ==== image.name
 

--- a/test/test-golden/nested-linked.adoc
+++ b/test/test-golden/nested-linked.adoc
@@ -2,6 +2,7 @@
 * link:#reference-bufferview[`Buffer View`]
 * link:#reference-extension[`Extension`]
 * link:#reference-extras[`Extras`]
+* link:#reference-image[`Image`]
 * link:#reference-material[`Material`]
 ** link:#reference-material-pbrmetallicroughness[`PBR Metallic Roughness`]
 * link:#reference-nestedtest[`nestedTest`] (root object)
@@ -140,6 +141,103 @@ Additional properties are allowed.
 Application-specific data.
 
 **Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability.
+
+
+
+'''
+[#reference-image]
+=== Image
+
+Image data used to create a texture. Image can be referenced by URI or `bufferView` index. `mimeType` is required in the latter case.
+
+.`Image` Properties
+|===
+|   |Type|Description|Required
+
+|**uri**
+|`string`
+|The uri of the image.
+|No
+
+|**mimeType**
+|`string`
+|The image's MIME type. Required if `bufferView` is defined.
+|No
+
+|**bufferView**
+|`integer`
+|The index of the bufferView that contains the image. Use this instead of the image's uri property.
+|No
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/image.schema.json[image.schema.json]
+
+==== image.uri
+
+The uri of the image.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: uriref
+
+==== image.mimeType
+
+The image's MIME type. Required if `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Allowed values**:
+** `"image/jpeg"`
+** `"image/png"`
+
+==== image.bufferView
+
+The index of the bufferView that contains the image. Use this instead of the image's uri property.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+==== image.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+==== image.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: Extension
+
+==== image.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
 
 
 
@@ -370,6 +468,11 @@ The root object for a nestedTest asset.
 |An array of materials.
 |No
 
+|**images**
+|link:#reference-image[`image`] `[1-*]`
+|An array of images.
+|No
+
 |**version**
 |`string`
 |A version string with a specific pattern.
@@ -408,6 +511,13 @@ An array of bufferViews.  This is the detailed description of the property.
 An array of materials.  This is the detailed description of the property.
 
 * **Type**: link:#reference-material[`material`] `[1-*]`
+* **Required**: No
+
+==== nestedTest.images
+
+An array of images.  This is the detailed description of the property.
+
+* **Type**: link:#reference-image[`image`] `[1-*]`
 * **Required**: No
 
 ==== nestedTest.version

--- a/test/test-golden/nested-linked.adoc
+++ b/test/test-golden/nested-linked.adoc
@@ -370,6 +370,16 @@ The root object for a nestedTest asset.
 |An array of materials.
 |No
 
+|**version**
+|`string`
+|A version string with a specific pattern.
+|No
+
+|**uri**
+|`string`
+|A string that should reference a URI.
+|No
+
 |**extensions**
 |link:#reference-extension[`extension`]
 |Dictionary object with extension-specific objects.
@@ -399,6 +409,21 @@ An array of materials.  This is the detailed description of the property.
 
 * **Type**: link:#reference-material[`material`] `[1-*]`
 * **Required**: No
+
+==== nestedTest.version
+
+A version string with a specific pattern.
+
+* **Type**: `string`
+* **Required**: No
+
+==== nestedTest.uri
+
+A string that should reference a URI.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: uriref
 
 ==== nestedTest.extensions
 

--- a/test/test-golden/nested-linked.adoc
+++ b/test/test-golden/nested-linked.adoc
@@ -1,0 +1,420 @@
+== Objects
+* link:#reference-bufferview[`Buffer View`]
+* link:#reference-extension[`Extension`]
+* link:#reference-extras[`Extras`]
+* link:#reference-material[`Material`]
+** link:#reference-material-pbrmetallicroughness[`PBR Metallic Roughness`]
+* link:#reference-nestedtest[`nestedTest`] (root object)
+
+
+'''
+[#reference-bufferview]
+=== Buffer View
+
+A view into a buffer.
+
+.`Buffer View` Properties
+|===
+|   |Type|Description|Required
+
+|**byteOffset**
+|`integer`
+|The offset into the buffer in bytes.
+|No, default: `0`
+
+|**byteLength**
+|`integer`
+|The length of the bufferView in bytes.
+| &#x2705; Yes
+
+|**byteStride**
+|`integer`
+|The stride, in bytes.
+|No
+
+|**target**
+|`integer`
+|This is a test of some enums.
+|No
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/bufferView.schema.json[bufferView.schema.json]
+
+==== bufferView.byteOffset
+
+The offset into the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+==== bufferView.byteLength &#x2705; 
+
+The length of the bufferView in bytes.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 1`
+
+==== bufferView.byteStride
+
+The stride, in bytes, between vertex attributes.  This is the detailed description of the property.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 4`
+* **Maximum**: ` <= 252`
+* **Related WebGL functions**: `vertexAttribPointer()` stride parameter
+
+==== bufferView.target
+
+This is a test of some enums.
+
+* **Type**: `integer`
+* **Required**: No
+* **Allowed values**:
+** `34962` ARRAY_BUFFER
+** `34963` ELEMENT_ARRAY_BUFFER
+* **Related WebGL functions**: `bindBuffer()`
+
+==== bufferView.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+==== bufferView.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: Extension
+
+==== bufferView.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-extension]
+=== Extension
+
+Dictionary object with extension-specific objects.
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/extension.schema.json[extension.schema.json]
+
+
+
+
+'''
+[#reference-extras]
+=== Extras
+
+Application-specific data.
+
+**Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability.
+
+
+
+'''
+[#reference-material]
+=== Material
+
+The material appearance of a primitive.
+
+.`Material` Properties
+|===
+|   |Type|Description|Required
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|**pbrMetallicRoughness**
+|link:#reference-material-pbrmetallicroughness[`material.pbrMetallicRoughness`]
+|A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
+|No
+
+|**emissiveFactor**
+|`number` `[3]`
+|The emissive color of the material.
+|No, default: `[0,0,0]`
+
+|**alphaMode**
+|`string`
+|The alpha rendering mode of the material.
+|No, default: `"OPAQUE"`
+
+|**alphaCutoff**
+|`number`
+|The alpha cutoff value of the material.
+|No, default: `0.5`
+
+|**doubleSided**
+|`boolean`
+|Specifies whether the material is double sided.
+|No, default: `false`
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/material.schema.json[material.schema.json]
+
+==== material.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+==== material.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: Extension
+
+==== material.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+==== material.pbrMetallicRoughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
+
+* **Type**: link:#reference-material-pbrmetallicroughness[`material.pbrMetallicRoughness`]
+* **Required**: No
+
+==== material.emissiveFactor
+
+The RGB components of the emissive color of the material. This is the detailed description of the property.
+
+* **Type**: `number` `[3]`
+** Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[0,0,0]`
+
+==== material.alphaMode
+
+The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture.
+
+* **Type**: `string`
+* **Required**: No, default: `"OPAQUE"`
+* **Allowed values**:
+** `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
+** `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
+** `"BLEND"` The alpha value is used to composite the source and destination areas.
+
+==== material.alphaCutoff
+
+Specifies the cutoff threshold when in `MASK` mode. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `0.5`
+* **Minimum**: ` >= 0`
+
+==== material.doubleSided
+
+Specifies whether the material is double sided. This is the detailed description of the property.
+
+* **Type**: `boolean`
+* **Required**: No, default: `false`
+
+
+
+
+'''
+[#reference-material-pbrmetallicroughness]
+=== Material PBR Metallic Roughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
+
+.`Material PBR Metallic Roughness` Properties
+|===
+|   |Type|Description|Required
+
+|**baseColorFactor**
+|`number` `[4]`
+|The material's base color factor.
+|No, default: `[1,1,1,1]`
+
+|**metallicFactor**
+|`number`
+|The metalness of the material.
+|No, default: `1`
+
+|**roughnessFactor**
+|`number`
+|The roughness of the material.
+|No, default: `1`
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/material.pbrMetallicRoughness.schema.json[material.pbrMetallicRoughness.schema.json]
+
+==== material.pbrMetallicRoughness.baseColorFactor
+
+The RGBA components of the base color of the material. This is the detailed description of the property.
+
+* **Type**: `number` `[4]`
+** Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[1,1,1,1]`
+
+==== material.pbrMetallicRoughness.metallicFactor
+
+The metalness of the material. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+==== material.pbrMetallicRoughness.roughnessFactor
+
+The roughness of the material. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+==== material.pbrMetallicRoughness.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: Extension
+
+==== material.pbrMetallicRoughness.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-nestedtest]
+=== nestedTest
+
+The root object for a nestedTest asset.
+
+.`nestedTest` Properties
+|===
+|   |Type|Description|Required
+
+|**bufferViews**
+|link:#reference-bufferview[`bufferView`] `[1-*]`
+|An array of bufferViews.
+| &#x2705; Yes
+
+|**materials**
+|link:#reference-material[`material`] `[1-*]`
+|An array of materials.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/nestedTest.schema.json[nestedTest.schema.json]
+
+==== nestedTest.bufferViews &#x2705; 
+
+An array of bufferViews.  This is the detailed description of the property.
+
+* **Type**: link:#reference-bufferview[`bufferView`] `[1-*]`
+* **Required**: Yes
+
+==== nestedTest.materials
+
+An array of materials.  This is the detailed description of the property.
+
+* **Type**: link:#reference-material[`material`] `[1-*]`
+* **Required**: No
+
+==== nestedTest.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: Extension
+
+==== nestedTest.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+

--- a/test/test-golden/nested-linked.md
+++ b/test/test-golden/nested-linked.md
@@ -128,6 +128,7 @@ Image data used to create a texture. Image can be referenced by URI or `bufferVi
 |**uri**|`string`|The uri of the image.|No|
 |**mimeType**|`string`|The image's MIME type. Required if `bufferView` is defined.|No|
 |**bufferView**|`integer`|The index of the bufferView that contains the image. Use this instead of the image's uri property.|No|
+|**fraction**|`number`|A number that must be between zero and one.|No|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
@@ -161,6 +162,15 @@ The index of the bufferView that contains the image. Use this instead of the ima
 * **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
+
+#### image.fraction
+
+A number that must be between zero and one.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+* **Maximum**: ` < 1`
 
 #### image.name
 

--- a/test/test-golden/nested-linked.md
+++ b/test/test-golden/nested-linked.md
@@ -279,6 +279,8 @@ The root object for a nestedTest asset.
 |---|---|---|---|
 |**bufferViews**|[`bufferView`](#reference-bufferview) `[1-*]`|An array of bufferViews.| &#x2705; Yes|
 |**materials**|[`material`](#reference-material) `[1-*]`|An array of materials.|No|
+|**version**|`string`|A version string with a specific pattern.|No|
+|**uri**|`string`|A string that should reference a URI.|No|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
@@ -299,6 +301,21 @@ An array of materials.  This is the detailed description of the property.
 
 * **Type**: [`material`](#reference-material) `[1-*]`
 * **Required**: No
+
+#### nestedTest.version
+
+A version string with a specific pattern.
+
+* **Type**: `string`
+* **Required**: No
+
+#### nestedTest.uri
+
+A string that should reference a URI.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: uriref
 
 #### nestedTest.extensions
 

--- a/test/test-golden/nested-linked.md
+++ b/test/test-golden/nested-linked.md
@@ -2,6 +2,7 @@
 * [`Buffer View`](#reference-bufferview)
 * [`Extension`](#reference-extension)
 * [`Extras`](#reference-extras)
+* [`Image`](#reference-image)
 * [`Material`](#reference-material)
    * [`PBR Metallic Roughness`](#reference-material-pbrmetallicroughness)
 * [`nestedTest`](#reference-nestedtest) (root object)
@@ -111,6 +112,78 @@ Additional properties are allowed.
 Application-specific data.
 
 **Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability.
+
+
+
+---------------------------------------
+<a name="reference-image"></a>
+### Image
+
+Image data used to create a texture. Image can be referenced by URI or `bufferView` index. `mimeType` is required in the latter case.
+
+**`Image` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**uri**|`string`|The uri of the image.|No|
+|**mimeType**|`string`|The image's MIME type. Required if `bufferView` is defined.|No|
+|**bufferView**|`integer`|The index of the bufferView that contains the image. Use this instead of the image's uri property.|No|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [image.schema.json](schema/image.schema.json)
+
+#### image.uri
+
+The uri of the image.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: uriref
+
+#### image.mimeType
+
+The image's MIME type. Required if `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Allowed values**:
+   * `"image/jpeg"`
+   * `"image/png"`
+
+#### image.bufferView
+
+The index of the bufferView that contains the image. Use this instead of the image's uri property.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+#### image.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+#### image.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### image.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
 
 
 
@@ -279,6 +352,7 @@ The root object for a nestedTest asset.
 |---|---|---|---|
 |**bufferViews**|[`bufferView`](#reference-bufferview) `[1-*]`|An array of bufferViews.| &#x2705; Yes|
 |**materials**|[`material`](#reference-material) `[1-*]`|An array of materials.|No|
+|**images**|[`image`](#reference-image) `[1-*]`|An array of images.|No|
 |**version**|`string`|A version string with a specific pattern.|No|
 |**uri**|`string`|A string that should reference a URI.|No|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
@@ -300,6 +374,13 @@ An array of bufferViews.  This is the detailed description of the property.
 An array of materials.  This is the detailed description of the property.
 
 * **Type**: [`material`](#reference-material) `[1-*]`
+* **Required**: No
+
+#### nestedTest.images
+
+An array of images.  This is the detailed description of the property.
+
+* **Type**: [`image`](#reference-image) `[1-*]`
 * **Required**: No
 
 #### nestedTest.version

--- a/test/test-golden/nested-linked.md
+++ b/test/test-golden/nested-linked.md
@@ -1,0 +1,320 @@
+## Objects
+* [`Buffer View`](#reference-bufferview)
+* [`Extension`](#reference-extension)
+* [`Extras`](#reference-extras)
+* [`Material`](#reference-material)
+   * [`PBR Metallic Roughness`](#reference-material-pbrmetallicroughness)
+* [`nestedTest`](#reference-nestedtest) (root object)
+
+
+---------------------------------------
+<a name="reference-bufferview"></a>
+### Buffer View
+
+A view into a buffer.
+
+**`Buffer View` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**byteOffset**|`integer`|The offset into the buffer in bytes.|No, default: `0`|
+|**byteLength**|`integer`|The length of the bufferView in bytes.| &#x2705; Yes|
+|**byteStride**|`integer`|The stride, in bytes.|No|
+|**target**|`integer`|This is a test of some enums.|No|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [bufferView.schema.json](schema/bufferView.schema.json)
+
+#### bufferView.byteOffset
+
+The offset into the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### bufferView.byteLength &#x2705; 
+
+The length of the bufferView in bytes.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 1`
+
+#### bufferView.byteStride
+
+The stride, in bytes, between vertex attributes.  This is the detailed description of the property.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 4`
+* **Maximum**: ` <= 252`
+* **Related WebGL functions**: `vertexAttribPointer()` stride parameter
+
+#### bufferView.target
+
+This is a test of some enums.
+
+* **Type**: `integer`
+* **Required**: No
+* **Allowed values**:
+   * `34962` ARRAY_BUFFER
+   * `34963` ELEMENT_ARRAY_BUFFER
+* **Related WebGL functions**: `bindBuffer()`
+
+#### bufferView.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+#### bufferView.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### bufferView.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-extension"></a>
+### Extension
+
+Dictionary object with extension-specific objects.
+
+Additional properties are allowed.
+
+* **JSON schema**: [extension.schema.json](schema/extension.schema.json)
+
+
+
+
+---------------------------------------
+<a name="reference-extras"></a>
+### Extras
+
+Application-specific data.
+
+**Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability.
+
+
+
+---------------------------------------
+<a name="reference-material"></a>
+### Material
+
+The material appearance of a primitive.
+
+**`Material` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+|**pbrMetallicRoughness**|[`material.pbrMetallicRoughness`](#reference-material-pbrmetallicroughness)|A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.|No|
+|**emissiveFactor**|`number` `[3]`|The emissive color of the material.|No, default: `[0,0,0]`|
+|**alphaMode**|`string`|The alpha rendering mode of the material.|No, default: `"OPAQUE"`|
+|**alphaCutoff**|`number`|The alpha cutoff value of the material.|No, default: `0.5`|
+|**doubleSided**|`boolean`|Specifies whether the material is double sided.|No, default: `false`|
+
+Additional properties are allowed.
+
+* **JSON schema**: [material.schema.json](schema/material.schema.json)
+
+#### material.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+#### material.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### material.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+#### material.pbrMetallicRoughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
+
+* **Type**: [`material.pbrMetallicRoughness`](#reference-material-pbrmetallicroughness)
+* **Required**: No
+
+#### material.emissiveFactor
+
+The RGB components of the emissive color of the material. This is the detailed description of the property.
+
+* **Type**: `number` `[3]`
+   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[0,0,0]`
+
+#### material.alphaMode
+
+The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture.
+
+* **Type**: `string`
+* **Required**: No, default: `"OPAQUE"`
+* **Allowed values**:
+   * `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
+   * `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
+   * `"BLEND"` The alpha value is used to composite the source and destination areas.
+
+#### material.alphaCutoff
+
+Specifies the cutoff threshold when in `MASK` mode. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `0.5`
+* **Minimum**: ` >= 0`
+
+#### material.doubleSided
+
+Specifies whether the material is double sided. This is the detailed description of the property.
+
+* **Type**: `boolean`
+* **Required**: No, default: `false`
+
+
+
+
+---------------------------------------
+<a name="reference-material-pbrmetallicroughness"></a>
+### Material PBR Metallic Roughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
+
+**`Material PBR Metallic Roughness` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**baseColorFactor**|`number` `[4]`|The material's base color factor.|No, default: `[1,1,1,1]`|
+|**metallicFactor**|`number`|The metalness of the material.|No, default: `1`|
+|**roughnessFactor**|`number`|The roughness of the material.|No, default: `1`|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [material.pbrMetallicRoughness.schema.json](schema/material.pbrMetallicRoughness.schema.json)
+
+#### material.pbrMetallicRoughness.baseColorFactor
+
+The RGBA components of the base color of the material. This is the detailed description of the property.
+
+* **Type**: `number` `[4]`
+   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[1,1,1,1]`
+
+#### material.pbrMetallicRoughness.metallicFactor
+
+The metalness of the material. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+#### material.pbrMetallicRoughness.roughnessFactor
+
+The roughness of the material. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+#### material.pbrMetallicRoughness.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### material.pbrMetallicRoughness.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-nestedtest"></a>
+### nestedTest
+
+The root object for a nestedTest asset.
+
+**`nestedTest` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**bufferViews**|[`bufferView`](#reference-bufferview) `[1-*]`|An array of bufferViews.| &#x2705; Yes|
+|**materials**|[`material`](#reference-material) `[1-*]`|An array of materials.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [nestedTest.schema.json](schema/nestedTest.schema.json)
+
+#### nestedTest.bufferViews &#x2705; 
+
+An array of bufferViews.  This is the detailed description of the property.
+
+* **Type**: [`bufferView`](#reference-bufferview) `[1-*]`
+* **Required**: Yes
+
+#### nestedTest.materials
+
+An array of materials.  This is the detailed description of the property.
+
+* **Type**: [`material`](#reference-material) `[1-*]`
+* **Required**: No
+
+#### nestedTest.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### nestedTest.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+

--- a/test/test-golden/nested-remote.adoc
+++ b/test/test-golden/nested-remote.adoc
@@ -1,0 +1,420 @@
+== Objects
+* link:#reference-bufferview[`Buffer View`]
+* link:#reference-extension[`Extension`]
+* link:#reference-extras[`Extras`]
+* link:#reference-material[`Material`]
+** link:#reference-material-pbrmetallicroughness[`PBR Metallic Roughness`]
+* link:#reference-nestedtest[`nestedTest`] (root object)
+
+
+'''
+[#reference-bufferview]
+=== Buffer View
+
+A view into a buffer.
+
+.`Buffer View` Properties
+|===
+|   |Type|Description|Required
+
+|**byteOffset**
+|`integer`
+|The offset into the buffer in bytes.
+|No, default: `0`
+
+|**byteLength**
+|`integer`
+|The length of the bufferView in bytes.
+| &#x2705; Yes
+
+|**byteStride**
+|`integer`
+|The stride, in bytes.
+|No
+
+|**target**
+|`integer`
+|This is a test of some enums.
+|No
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/bufferView.schema.json[bufferView.schema.json]
+
+==== bufferView.byteOffset
+
+The offset into the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+==== bufferView.byteLength &#x2705; 
+
+The length of the bufferView in bytes.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 1`
+
+==== bufferView.byteStride
+
+The stride, in bytes, between vertex attributes.  This is the detailed description of the property.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 4`
+* **Maximum**: ` <= 252`
+* **Related WebGL functions**: `vertexAttribPointer()` stride parameter
+
+==== bufferView.target
+
+This is a test of some enums.
+
+* **Type**: `integer`
+* **Required**: No
+* **Allowed values**:
+** `34962` ARRAY_BUFFER
+** `34963` ELEMENT_ARRAY_BUFFER
+* **Related WebGL functions**: `bindBuffer()`
+
+==== bufferView.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+==== bufferView.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: Extension
+
+==== bufferView.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-extension]
+=== Extension
+
+Dictionary object with extension-specific objects.
+
+Additional properties are allowed.
+
+* **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/extension.schema.json[extension.schema.json]
+
+
+
+
+'''
+[#reference-extras]
+=== Extras
+
+Application-specific data.
+
+**Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability.
+
+
+
+'''
+[#reference-material]
+=== Material
+
+The material appearance of a primitive.
+
+.`Material` Properties
+|===
+|   |Type|Description|Required
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|**pbrMetallicRoughness**
+|link:#reference-material-pbrmetallicroughness[`material.pbrMetallicRoughness`]
+|A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
+|No
+
+|**emissiveFactor**
+|`number` `[3]`
+|The emissive color of the material.
+|No, default: `[0,0,0]`
+
+|**alphaMode**
+|`string`
+|The alpha rendering mode of the material.
+|No, default: `"OPAQUE"`
+
+|**alphaCutoff**
+|`number`
+|The alpha cutoff value of the material.
+|No, default: `0.5`
+
+|**doubleSided**
+|`boolean`
+|Specifies whether the material is double sided.
+|No, default: `false`
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/material.schema.json[material.schema.json]
+
+==== material.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+==== material.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: Extension
+
+==== material.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+==== material.pbrMetallicRoughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
+
+* **Type**: link:#reference-material-pbrmetallicroughness[`material.pbrMetallicRoughness`]
+* **Required**: No
+
+==== material.emissiveFactor
+
+The RGB components of the emissive color of the material. This is the detailed description of the property.
+
+* **Type**: `number` `[3]`
+** Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[0,0,0]`
+
+==== material.alphaMode
+
+The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture.
+
+* **Type**: `string`
+* **Required**: No, default: `"OPAQUE"`
+* **Allowed values**:
+** `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
+** `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
+** `"BLEND"` The alpha value is used to composite the source and destination areas.
+
+==== material.alphaCutoff
+
+Specifies the cutoff threshold when in `MASK` mode. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `0.5`
+* **Minimum**: ` >= 0`
+
+==== material.doubleSided
+
+Specifies whether the material is double sided. This is the detailed description of the property.
+
+* **Type**: `boolean`
+* **Required**: No, default: `false`
+
+
+
+
+'''
+[#reference-material-pbrmetallicroughness]
+=== Material PBR Metallic Roughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
+
+.`Material PBR Metallic Roughness` Properties
+|===
+|   |Type|Description|Required
+
+|**baseColorFactor**
+|`number` `[4]`
+|The material's base color factor.
+|No, default: `[1,1,1,1]`
+
+|**metallicFactor**
+|`number`
+|The metalness of the material.
+|No, default: `1`
+
+|**roughnessFactor**
+|`number`
+|The roughness of the material.
+|No, default: `1`
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/material.pbrMetallicRoughness.schema.json[material.pbrMetallicRoughness.schema.json]
+
+==== material.pbrMetallicRoughness.baseColorFactor
+
+The RGBA components of the base color of the material. This is the detailed description of the property.
+
+* **Type**: `number` `[4]`
+** Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[1,1,1,1]`
+
+==== material.pbrMetallicRoughness.metallicFactor
+
+The metalness of the material. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+==== material.pbrMetallicRoughness.roughnessFactor
+
+The roughness of the material. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+==== material.pbrMetallicRoughness.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: Extension
+
+==== material.pbrMetallicRoughness.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+
+'''
+[#reference-nestedtest]
+=== nestedTest
+
+The root object for a nestedTest asset.
+
+.`nestedTest` Properties
+|===
+|   |Type|Description|Required
+
+|**bufferViews**
+|link:#reference-bufferview[`bufferView`] `[1-*]`
+|An array of bufferViews.
+| &#x2705; Yes
+
+|**materials**
+|link:#reference-material[`material`] `[1-*]`
+|An array of materials.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/nestedTest.schema.json[nestedTest.schema.json]
+
+==== nestedTest.bufferViews &#x2705; 
+
+An array of bufferViews.  This is the detailed description of the property.
+
+* **Type**: link:#reference-bufferview[`bufferView`] `[1-*]`
+* **Required**: Yes
+
+==== nestedTest.materials
+
+An array of materials.  This is the detailed description of the property.
+
+* **Type**: link:#reference-material[`material`] `[1-*]`
+* **Required**: No
+
+==== nestedTest.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: Extension
+
+==== nestedTest.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
+
+
+

--- a/test/test-golden/nested-remote.adoc
+++ b/test/test-golden/nested-remote.adoc
@@ -169,6 +169,11 @@ Image data used to create a texture. Image can be referenced by URI or `bufferVi
 |The index of the bufferView that contains the image. Use this instead of the image's uri property.
 |No
 
+|**fraction**
+|`number`
+|A number that must be between zero and one.
+|No
+
 |**name**
 |`string`
 |The user-defined name of this object.
@@ -215,6 +220,15 @@ The index of the bufferView that contains the image. Use this instead of the ima
 * **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
+
+==== image.fraction
+
+A number that must be between zero and one.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+* **Maximum**: ` < 1`
 
 ==== image.name
 

--- a/test/test-golden/nested-remote.adoc
+++ b/test/test-golden/nested-remote.adoc
@@ -2,6 +2,7 @@
 * link:#reference-bufferview[`Buffer View`]
 * link:#reference-extension[`Extension`]
 * link:#reference-extras[`Extras`]
+* link:#reference-image[`Image`]
 * link:#reference-material[`Material`]
 ** link:#reference-material-pbrmetallicroughness[`PBR Metallic Roughness`]
 * link:#reference-nestedtest[`nestedTest`] (root object)
@@ -140,6 +141,103 @@ Additional properties are allowed.
 Application-specific data.
 
 **Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability.
+
+
+
+'''
+[#reference-image]
+=== Image
+
+Image data used to create a texture. Image can be referenced by URI or `bufferView` index. `mimeType` is required in the latter case.
+
+.`Image` Properties
+|===
+|   |Type|Description|Required
+
+|**uri**
+|`string`
+|The uri of the image.
+|No
+
+|**mimeType**
+|`string`
+|The image's MIME type. Required if `bufferView` is defined.
+|No
+
+|**bufferView**
+|`integer`
+|The index of the bufferView that contains the image. Use this instead of the image's uri property.
+|No
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|link:#reference-extension[`extension`]
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|link:#reference-extras[`extras`]
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/image.schema.json[image.schema.json]
+
+==== image.uri
+
+The uri of the image.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: uriref
+
+==== image.mimeType
+
+The image's MIME type. Required if `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Allowed values**:
+** `"image/jpeg"`
+** `"image/png"`
+
+==== image.bufferView
+
+The index of the bufferView that contains the image. Use this instead of the image's uri property.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+==== image.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+==== image.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: link:#reference-extension[`extension`]
+* **Required**: No
+* **Type of each property**: Extension
+
+==== image.extras
+
+Application-specific data.
+
+* **Type**: link:#reference-extras[`extras`]
+* **Required**: No
+
 
 
 
@@ -370,6 +468,11 @@ The root object for a nestedTest asset.
 |An array of materials.
 |No
 
+|**images**
+|link:#reference-image[`image`] `[1-*]`
+|An array of images.
+|No
+
 |**version**
 |`string`
 |A version string with a specific pattern.
@@ -408,6 +511,13 @@ An array of bufferViews.  This is the detailed description of the property.
 An array of materials.  This is the detailed description of the property.
 
 * **Type**: link:#reference-material[`material`] `[1-*]`
+* **Required**: No
+
+==== nestedTest.images
+
+An array of images.  This is the detailed description of the property.
+
+* **Type**: link:#reference-image[`image`] `[1-*]`
 * **Required**: No
 
 ==== nestedTest.version

--- a/test/test-golden/nested-remote.adoc
+++ b/test/test-golden/nested-remote.adoc
@@ -370,6 +370,16 @@ The root object for a nestedTest asset.
 |An array of materials.
 |No
 
+|**version**
+|`string`
+|A version string with a specific pattern.
+|No
+
+|**uri**
+|`string`
+|A string that should reference a URI.
+|No
+
 |**extensions**
 |link:#reference-extension[`extension`]
 |Dictionary object with extension-specific objects.
@@ -399,6 +409,21 @@ An array of materials.  This is the detailed description of the property.
 
 * **Type**: link:#reference-material[`material`] `[1-*]`
 * **Required**: No
+
+==== nestedTest.version
+
+A version string with a specific pattern.
+
+* **Type**: `string`
+* **Required**: No
+
+==== nestedTest.uri
+
+A string that should reference a URI.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: uriref
 
 ==== nestedTest.extensions
 

--- a/test/test-golden/nested-remote.md
+++ b/test/test-golden/nested-remote.md
@@ -2,6 +2,7 @@
 * [`Buffer View`](#reference-bufferview)
 * [`Extension`](#reference-extension)
 * [`Extras`](#reference-extras)
+* [`Image`](#reference-image)
 * [`Material`](#reference-material)
    * [`PBR Metallic Roughness`](#reference-material-pbrmetallicroughness)
 * [`nestedTest`](#reference-nestedtest) (root object)
@@ -111,6 +112,78 @@ Additional properties are allowed.
 Application-specific data.
 
 **Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability.
+
+
+
+---------------------------------------
+<a name="reference-image"></a>
+### Image
+
+Image data used to create a texture. Image can be referenced by URI or `bufferView` index. `mimeType` is required in the latter case.
+
+**`Image` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**uri**|`string`|The uri of the image.|No|
+|**mimeType**|`string`|The image's MIME type. Required if `bufferView` is defined.|No|
+|**bufferView**|`integer`|The index of the bufferView that contains the image. Use this instead of the image's uri property.|No|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [image.schema.json](https://www.khronos.org/wetzel/just/testing/schema/image.schema.json)
+
+#### image.uri
+
+The uri of the image.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: uriref
+
+#### image.mimeType
+
+The image's MIME type. Required if `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Allowed values**:
+   * `"image/jpeg"`
+   * `"image/png"`
+
+#### image.bufferView
+
+The index of the bufferView that contains the image. Use this instead of the image's uri property.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+#### image.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+#### image.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### image.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
 
 
 
@@ -279,6 +352,7 @@ The root object for a nestedTest asset.
 |---|---|---|---|
 |**bufferViews**|[`bufferView`](#reference-bufferview) `[1-*]`|An array of bufferViews.| &#x2705; Yes|
 |**materials**|[`material`](#reference-material) `[1-*]`|An array of materials.|No|
+|**images**|[`image`](#reference-image) `[1-*]`|An array of images.|No|
 |**version**|`string`|A version string with a specific pattern.|No|
 |**uri**|`string`|A string that should reference a URI.|No|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
@@ -300,6 +374,13 @@ An array of bufferViews.  This is the detailed description of the property.
 An array of materials.  This is the detailed description of the property.
 
 * **Type**: [`material`](#reference-material) `[1-*]`
+* **Required**: No
+
+#### nestedTest.images
+
+An array of images.  This is the detailed description of the property.
+
+* **Type**: [`image`](#reference-image) `[1-*]`
 * **Required**: No
 
 #### nestedTest.version

--- a/test/test-golden/nested-remote.md
+++ b/test/test-golden/nested-remote.md
@@ -1,0 +1,320 @@
+## Objects
+* [`Buffer View`](#reference-bufferview)
+* [`Extension`](#reference-extension)
+* [`Extras`](#reference-extras)
+* [`Material`](#reference-material)
+   * [`PBR Metallic Roughness`](#reference-material-pbrmetallicroughness)
+* [`nestedTest`](#reference-nestedtest) (root object)
+
+
+---------------------------------------
+<a name="reference-bufferview"></a>
+### Buffer View
+
+A view into a buffer.
+
+**`Buffer View` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**byteOffset**|`integer`|The offset into the buffer in bytes.|No, default: `0`|
+|**byteLength**|`integer`|The length of the bufferView in bytes.| &#x2705; Yes|
+|**byteStride**|`integer`|The stride, in bytes.|No|
+|**target**|`integer`|This is a test of some enums.|No|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [bufferView.schema.json](https://www.khronos.org/wetzel/just/testing/schema/bufferView.schema.json)
+
+#### bufferView.byteOffset
+
+The offset into the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+#### bufferView.byteLength &#x2705; 
+
+The length of the bufferView in bytes.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 1`
+
+#### bufferView.byteStride
+
+The stride, in bytes, between vertex attributes.  This is the detailed description of the property.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 4`
+* **Maximum**: ` <= 252`
+* **Related WebGL functions**: `vertexAttribPointer()` stride parameter
+
+#### bufferView.target
+
+This is a test of some enums.
+
+* **Type**: `integer`
+* **Required**: No
+* **Allowed values**:
+   * `34962` ARRAY_BUFFER
+   * `34963` ELEMENT_ARRAY_BUFFER
+* **Related WebGL functions**: `bindBuffer()`
+
+#### bufferView.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+#### bufferView.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### bufferView.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-extension"></a>
+### Extension
+
+Dictionary object with extension-specific objects.
+
+Additional properties are allowed.
+
+* **JSON schema**: [extension.schema.json](https://www.khronos.org/wetzel/just/testing/schema/extension.schema.json)
+
+
+
+
+---------------------------------------
+<a name="reference-extras"></a>
+### Extras
+
+Application-specific data.
+
+**Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability.
+
+
+
+---------------------------------------
+<a name="reference-material"></a>
+### Material
+
+The material appearance of a primitive.
+
+**`Material` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+|**pbrMetallicRoughness**|[`material.pbrMetallicRoughness`](#reference-material-pbrmetallicroughness)|A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.|No|
+|**emissiveFactor**|`number` `[3]`|The emissive color of the material.|No, default: `[0,0,0]`|
+|**alphaMode**|`string`|The alpha rendering mode of the material.|No, default: `"OPAQUE"`|
+|**alphaCutoff**|`number`|The alpha cutoff value of the material.|No, default: `0.5`|
+|**doubleSided**|`boolean`|Specifies whether the material is double sided.|No, default: `false`|
+
+Additional properties are allowed.
+
+* **JSON schema**: [material.schema.json](https://www.khronos.org/wetzel/just/testing/schema/material.schema.json)
+
+#### material.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+#### material.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### material.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+#### material.pbrMetallicRoughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
+
+* **Type**: [`material.pbrMetallicRoughness`](#reference-material-pbrmetallicroughness)
+* **Required**: No
+
+#### material.emissiveFactor
+
+The RGB components of the emissive color of the material. This is the detailed description of the property.
+
+* **Type**: `number` `[3]`
+   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[0,0,0]`
+
+#### material.alphaMode
+
+The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture.
+
+* **Type**: `string`
+* **Required**: No, default: `"OPAQUE"`
+* **Allowed values**:
+   * `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
+   * `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
+   * `"BLEND"` The alpha value is used to composite the source and destination areas.
+
+#### material.alphaCutoff
+
+Specifies the cutoff threshold when in `MASK` mode. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `0.5`
+* **Minimum**: ` >= 0`
+
+#### material.doubleSided
+
+Specifies whether the material is double sided. This is the detailed description of the property.
+
+* **Type**: `boolean`
+* **Required**: No, default: `false`
+
+
+
+
+---------------------------------------
+<a name="reference-material-pbrmetallicroughness"></a>
+### Material PBR Metallic Roughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
+
+**`Material PBR Metallic Roughness` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**baseColorFactor**|`number` `[4]`|The material's base color factor.|No, default: `[1,1,1,1]`|
+|**metallicFactor**|`number`|The metalness of the material.|No, default: `1`|
+|**roughnessFactor**|`number`|The roughness of the material.|No, default: `1`|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [material.pbrMetallicRoughness.schema.json](https://www.khronos.org/wetzel/just/testing/schema/material.pbrMetallicRoughness.schema.json)
+
+#### material.pbrMetallicRoughness.baseColorFactor
+
+The RGBA components of the base color of the material. This is the detailed description of the property.
+
+* **Type**: `number` `[4]`
+   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[1,1,1,1]`
+
+#### material.pbrMetallicRoughness.metallicFactor
+
+The metalness of the material. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+#### material.pbrMetallicRoughness.roughnessFactor
+
+The roughness of the material. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+#### material.pbrMetallicRoughness.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### material.pbrMetallicRoughness.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-nestedtest"></a>
+### nestedTest
+
+The root object for a nestedTest asset.
+
+**`nestedTest` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**bufferViews**|[`bufferView`](#reference-bufferview) `[1-*]`|An array of bufferViews.| &#x2705; Yes|
+|**materials**|[`material`](#reference-material) `[1-*]`|An array of materials.|No|
+|**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
+|**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [nestedTest.schema.json](https://www.khronos.org/wetzel/just/testing/schema/nestedTest.schema.json)
+
+#### nestedTest.bufferViews &#x2705; 
+
+An array of bufferViews.  This is the detailed description of the property.
+
+* **Type**: [`bufferView`](#reference-bufferview) `[1-*]`
+* **Required**: Yes
+
+#### nestedTest.materials
+
+An array of materials.  This is the detailed description of the property.
+
+* **Type**: [`material`](#reference-material) `[1-*]`
+* **Required**: No
+
+#### nestedTest.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: [`extension`](#reference-extension)
+* **Required**: No
+* **Type of each property**: Extension
+
+#### nestedTest.extras
+
+Application-specific data.
+
+* **Type**: [`extras`](#reference-extras)
+* **Required**: No
+
+
+
+

--- a/test/test-golden/nested-remote.md
+++ b/test/test-golden/nested-remote.md
@@ -128,6 +128,7 @@ Image data used to create a texture. Image can be referenced by URI or `bufferVi
 |**uri**|`string`|The uri of the image.|No|
 |**mimeType**|`string`|The image's MIME type. Required if `bufferView` is defined.|No|
 |**bufferView**|`integer`|The index of the bufferView that contains the image. Use this instead of the image's uri property.|No|
+|**fraction**|`number`|A number that must be between zero and one.|No|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
@@ -161,6 +162,15 @@ The index of the bufferView that contains the image. Use this instead of the ima
 * **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
+
+#### image.fraction
+
+A number that must be between zero and one.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+* **Maximum**: ` < 1`
 
 #### image.name
 

--- a/test/test-golden/nested-remote.md
+++ b/test/test-golden/nested-remote.md
@@ -279,6 +279,8 @@ The root object for a nestedTest asset.
 |---|---|---|---|
 |**bufferViews**|[`bufferView`](#reference-bufferview) `[1-*]`|An array of bufferViews.| &#x2705; Yes|
 |**materials**|[`material`](#reference-material) `[1-*]`|An array of materials.|No|
+|**version**|`string`|A version string with a specific pattern.|No|
+|**uri**|`string`|A string that should reference a URI.|No|
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
@@ -299,6 +301,21 @@ An array of materials.  This is the detailed description of the property.
 
 * **Type**: [`material`](#reference-material) `[1-*]`
 * **Required**: No
+
+#### nestedTest.version
+
+A version string with a specific pattern.
+
+* **Type**: `string`
+* **Required**: No
+
+#### nestedTest.uri
+
+A string that should reference a URI.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: uriref
 
 #### nestedTest.extensions
 

--- a/test/test-golden/nested-simple.adoc
+++ b/test/test-golden/nested-simple.adoc
@@ -2,6 +2,7 @@
 * link:#reference-bufferview[`Buffer View`]
 * link:#reference-extension[`Extension`]
 * link:#reference-extras[`Extras`]
+* link:#reference-image[`Image`]
 * link:#reference-material[`Material`]
 ** link:#reference-material-pbrmetallicroughness[`PBR Metallic Roughness`]
 * link:#reference-nestedtest[`nestedTest`] (root object)
@@ -136,6 +137,101 @@ Additional properties are allowed.
 Application-specific data.
 
 **Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability.
+
+
+
+'''
+[#reference-image]
+== Image
+
+Image data used to create a texture. Image can be referenced by URI or `bufferView` index. `mimeType` is required in the latter case.
+
+.`Image` Properties
+|===
+|   |Type|Description|Required
+
+|**uri**
+|`string`
+|The uri of the image.
+|No
+
+|**mimeType**
+|`string`
+|The image's MIME type. Required if `bufferView` is defined.
+|No
+
+|**bufferView**
+|`integer`
+|The index of the bufferView that contains the image. Use this instead of the image's uri property.
+|No
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|`extension`
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|`extras`
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+=== image.uri
+
+The uri of the image.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: uriref
+
+=== image.mimeType
+
+The image's MIME type. Required if `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Allowed values**:
+** `"image/jpeg"`
+** `"image/png"`
+
+=== image.bufferView
+
+The index of the bufferView that contains the image. Use this instead of the image's uri property.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+=== image.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+=== image.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `extension`
+* **Required**: No
+* **Type of each property**: Extension
+
+=== image.extras
+
+Application-specific data.
+
+* **Type**: `extras`
+* **Required**: No
+
 
 
 
@@ -362,6 +458,11 @@ The root object for a nestedTest asset.
 |An array of materials.
 |No
 
+|**images**
+|`image` `[1-*]`
+|An array of images.
+|No
+
 |**version**
 |`string`
 |A version string with a specific pattern.
@@ -398,6 +499,13 @@ An array of bufferViews.  This is the detailed description of the property.
 An array of materials.  This is the detailed description of the property.
 
 * **Type**: `material` `[1-*]`
+* **Required**: No
+
+=== nestedTest.images
+
+An array of images.  This is the detailed description of the property.
+
+* **Type**: `image` `[1-*]`
 * **Required**: No
 
 === nestedTest.version

--- a/test/test-golden/nested-simple.adoc
+++ b/test/test-golden/nested-simple.adoc
@@ -1,0 +1,410 @@
+= Objects
+* link:#reference-bufferview[`Buffer View`]
+* link:#reference-extension[`Extension`]
+* link:#reference-extras[`Extras`]
+* link:#reference-material[`Material`]
+** link:#reference-material-pbrmetallicroughness[`PBR Metallic Roughness`]
+* link:#reference-nestedtest[`nestedTest`] (root object)
+
+
+'''
+[#reference-bufferview]
+== Buffer View
+
+A view into a buffer.
+
+.`Buffer View` Properties
+|===
+|   |Type|Description|Required
+
+|**byteOffset**
+|`integer`
+|The offset into the buffer in bytes.
+|No, default: `0`
+
+|**byteLength**
+|`integer`
+|The length of the bufferView in bytes.
+| &#x2705; Yes
+
+|**byteStride**
+|`integer`
+|The stride, in bytes.
+|No
+
+|**target**
+|`integer`
+|This is a test of some enums.
+|No
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|`extension`
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|`extras`
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+=== bufferView.byteOffset
+
+The offset into the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+=== bufferView.byteLength &#x2705; 
+
+The length of the bufferView in bytes.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 1`
+
+=== bufferView.byteStride
+
+The stride, in bytes, between vertex attributes.  This is the detailed description of the property.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 4`
+* **Maximum**: ` <= 252`
+* **Related WebGL functions**: `vertexAttribPointer()` stride parameter
+
+=== bufferView.target
+
+This is a test of some enums.
+
+* **Type**: `integer`
+* **Required**: No
+* **Allowed values**:
+** `34962` ARRAY_BUFFER
+** `34963` ELEMENT_ARRAY_BUFFER
+* **Related WebGL functions**: `bindBuffer()`
+
+=== bufferView.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+=== bufferView.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `extension`
+* **Required**: No
+* **Type of each property**: Extension
+
+=== bufferView.extras
+
+Application-specific data.
+
+* **Type**: `extras`
+* **Required**: No
+
+
+
+
+'''
+[#reference-extension]
+== Extension
+
+Dictionary object with extension-specific objects.
+
+Additional properties are allowed.
+
+
+
+
+'''
+[#reference-extras]
+== Extras
+
+Application-specific data.
+
+**Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability.
+
+
+
+'''
+[#reference-material]
+== Material
+
+The material appearance of a primitive.
+
+.`Material` Properties
+|===
+|   |Type|Description|Required
+
+|**name**
+|`string`
+|The user-defined name of this object.
+|No
+
+|**extensions**
+|`extension`
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|`extras`
+|Application-specific data.
+|No
+
+|**pbrMetallicRoughness**
+|`material.pbrMetallicRoughness`
+|A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
+|No
+
+|**emissiveFactor**
+|`number` `[3]`
+|The emissive color of the material.
+|No, default: `[0,0,0]`
+
+|**alphaMode**
+|`string`
+|The alpha rendering mode of the material.
+|No, default: `"OPAQUE"`
+
+|**alphaCutoff**
+|`number`
+|The alpha cutoff value of the material.
+|No, default: `0.5`
+
+|**doubleSided**
+|`boolean`
+|Specifies whether the material is double sided.
+|No, default: `false`
+
+|===
+
+Additional properties are allowed.
+
+=== material.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+=== material.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `extension`
+* **Required**: No
+* **Type of each property**: Extension
+
+=== material.extras
+
+Application-specific data.
+
+* **Type**: `extras`
+* **Required**: No
+
+=== material.pbrMetallicRoughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
+
+* **Type**: `material.pbrMetallicRoughness`
+* **Required**: No
+
+=== material.emissiveFactor
+
+The RGB components of the emissive color of the material. This is the detailed description of the property.
+
+* **Type**: `number` `[3]`
+** Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[0,0,0]`
+
+=== material.alphaMode
+
+The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture.
+
+* **Type**: `string`
+* **Required**: No, default: `"OPAQUE"`
+* **Allowed values**:
+** `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
+** `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
+** `"BLEND"` The alpha value is used to composite the source and destination areas.
+
+=== material.alphaCutoff
+
+Specifies the cutoff threshold when in `MASK` mode. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `0.5`
+* **Minimum**: ` >= 0`
+
+=== material.doubleSided
+
+Specifies whether the material is double sided. This is the detailed description of the property.
+
+* **Type**: `boolean`
+* **Required**: No, default: `false`
+
+
+
+
+'''
+[#reference-material-pbrmetallicroughness]
+== Material PBR Metallic Roughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
+
+.`Material PBR Metallic Roughness` Properties
+|===
+|   |Type|Description|Required
+
+|**baseColorFactor**
+|`number` `[4]`
+|The material's base color factor.
+|No, default: `[1,1,1,1]`
+
+|**metallicFactor**
+|`number`
+|The metalness of the material.
+|No, default: `1`
+
+|**roughnessFactor**
+|`number`
+|The roughness of the material.
+|No, default: `1`
+
+|**extensions**
+|`extension`
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|`extras`
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+=== material.pbrMetallicRoughness.baseColorFactor
+
+The RGBA components of the base color of the material. This is the detailed description of the property.
+
+* **Type**: `number` `[4]`
+** Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[1,1,1,1]`
+
+=== material.pbrMetallicRoughness.metallicFactor
+
+The metalness of the material. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+=== material.pbrMetallicRoughness.roughnessFactor
+
+The roughness of the material. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+=== material.pbrMetallicRoughness.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `extension`
+* **Required**: No
+* **Type of each property**: Extension
+
+=== material.pbrMetallicRoughness.extras
+
+Application-specific data.
+
+* **Type**: `extras`
+* **Required**: No
+
+
+
+
+'''
+[#reference-nestedtest]
+== nestedTest
+
+The root object for a nestedTest asset.
+
+.`nestedTest` Properties
+|===
+|   |Type|Description|Required
+
+|**bufferViews**
+|`bufferView` `[1-*]`
+|An array of bufferViews.
+| &#x2705; Yes
+
+|**materials**
+|`material` `[1-*]`
+|An array of materials.
+|No
+
+|**extensions**
+|`extension`
+|Dictionary object with extension-specific objects.
+|No
+
+|**extras**
+|`extras`
+|Application-specific data.
+|No
+
+|===
+
+Additional properties are allowed.
+
+=== nestedTest.bufferViews &#x2705; 
+
+An array of bufferViews.  This is the detailed description of the property.
+
+* **Type**: `bufferView` `[1-*]`
+* **Required**: Yes
+
+=== nestedTest.materials
+
+An array of materials.  This is the detailed description of the property.
+
+* **Type**: `material` `[1-*]`
+* **Required**: No
+
+=== nestedTest.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `extension`
+* **Required**: No
+* **Type of each property**: Extension
+
+=== nestedTest.extras
+
+Application-specific data.
+
+* **Type**: `extras`
+* **Required**: No
+
+
+
+

--- a/test/test-golden/nested-simple.adoc
+++ b/test/test-golden/nested-simple.adoc
@@ -165,6 +165,11 @@ Image data used to create a texture. Image can be referenced by URI or `bufferVi
 |The index of the bufferView that contains the image. Use this instead of the image's uri property.
 |No
 
+|**fraction**
+|`number`
+|A number that must be between zero and one.
+|No
+
 |**name**
 |`string`
 |The user-defined name of this object.
@@ -209,6 +214,15 @@ The index of the bufferView that contains the image. Use this instead of the ima
 * **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
+
+=== image.fraction
+
+A number that must be between zero and one.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+* **Maximum**: ` < 1`
 
 === image.name
 

--- a/test/test-golden/nested-simple.adoc
+++ b/test/test-golden/nested-simple.adoc
@@ -362,6 +362,16 @@ The root object for a nestedTest asset.
 |An array of materials.
 |No
 
+|**version**
+|`string`
+|A version string with a specific pattern.
+|No
+
+|**uri**
+|`string`
+|A string that should reference a URI.
+|No
+
 |**extensions**
 |`extension`
 |Dictionary object with extension-specific objects.
@@ -389,6 +399,21 @@ An array of materials.  This is the detailed description of the property.
 
 * **Type**: `material` `[1-*]`
 * **Required**: No
+
+=== nestedTest.version
+
+A version string with a specific pattern.
+
+* **Type**: `string`
+* **Required**: No
+
+=== nestedTest.uri
+
+A string that should reference a URI.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: uriref
 
 === nestedTest.extensions
 

--- a/test/test-golden/nested-simple.md
+++ b/test/test-golden/nested-simple.md
@@ -271,6 +271,8 @@ The root object for a nestedTest asset.
 |---|---|---|---|
 |**bufferViews**|`bufferView` `[1-*]`|An array of bufferViews.| &#x2705; Yes|
 |**materials**|`material` `[1-*]`|An array of materials.|No|
+|**version**|`string`|A version string with a specific pattern.|No|
+|**uri**|`string`|A string that should reference a URI.|No|
 |**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
 |**extras**|`extras`|Application-specific data.|No|
 
@@ -289,6 +291,21 @@ An array of materials.  This is the detailed description of the property.
 
 * **Type**: `material` `[1-*]`
 * **Required**: No
+
+### nestedTest.version
+
+A version string with a specific pattern.
+
+* **Type**: `string`
+* **Required**: No
+
+### nestedTest.uri
+
+A string that should reference a URI.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: uriref
 
 ### nestedTest.extensions
 

--- a/test/test-golden/nested-simple.md
+++ b/test/test-golden/nested-simple.md
@@ -2,6 +2,7 @@
 * [`Buffer View`](#reference-bufferview)
 * [`Extension`](#reference-extension)
 * [`Extras`](#reference-extras)
+* [`Image`](#reference-image)
 * [`Material`](#reference-material)
    * [`PBR Metallic Roughness`](#reference-material-pbrmetallicroughness)
 * [`nestedTest`](#reference-nestedtest) (root object)
@@ -107,6 +108,76 @@ Additional properties are allowed.
 Application-specific data.
 
 **Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability.
+
+
+
+---------------------------------------
+<a name="reference-image"></a>
+## Image
+
+Image data used to create a texture. Image can be referenced by URI or `bufferView` index. `mimeType` is required in the latter case.
+
+**`Image` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**uri**|`string`|The uri of the image.|No|
+|**mimeType**|`string`|The image's MIME type. Required if `bufferView` is defined.|No|
+|**bufferView**|`integer`|The index of the bufferView that contains the image. Use this instead of the image's uri property.|No|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
+|**extras**|`extras`|Application-specific data.|No|
+
+Additional properties are allowed.
+
+### image.uri
+
+The uri of the image.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: uriref
+
+### image.mimeType
+
+The image's MIME type. Required if `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Allowed values**:
+   * `"image/jpeg"`
+   * `"image/png"`
+
+### image.bufferView
+
+The index of the bufferView that contains the image. Use this instead of the image's uri property.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+### image.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+### image.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `extension`
+* **Required**: No
+* **Type of each property**: Extension
+
+### image.extras
+
+Application-specific data.
+
+* **Type**: `extras`
+* **Required**: No
+
 
 
 
@@ -271,6 +342,7 @@ The root object for a nestedTest asset.
 |---|---|---|---|
 |**bufferViews**|`bufferView` `[1-*]`|An array of bufferViews.| &#x2705; Yes|
 |**materials**|`material` `[1-*]`|An array of materials.|No|
+|**images**|`image` `[1-*]`|An array of images.|No|
 |**version**|`string`|A version string with a specific pattern.|No|
 |**uri**|`string`|A string that should reference a URI.|No|
 |**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
@@ -290,6 +362,13 @@ An array of bufferViews.  This is the detailed description of the property.
 An array of materials.  This is the detailed description of the property.
 
 * **Type**: `material` `[1-*]`
+* **Required**: No
+
+### nestedTest.images
+
+An array of images.  This is the detailed description of the property.
+
+* **Type**: `image` `[1-*]`
 * **Required**: No
 
 ### nestedTest.version

--- a/test/test-golden/nested-simple.md
+++ b/test/test-golden/nested-simple.md
@@ -124,6 +124,7 @@ Image data used to create a texture. Image can be referenced by URI or `bufferVi
 |**uri**|`string`|The uri of the image.|No|
 |**mimeType**|`string`|The image's MIME type. Required if `bufferView` is defined.|No|
 |**bufferView**|`integer`|The index of the bufferView that contains the image. Use this instead of the image's uri property.|No|
+|**fraction**|`number`|A number that must be between zero and one.|No|
 |**name**|`string`|The user-defined name of this object.|No|
 |**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
 |**extras**|`extras`|Application-specific data.|No|
@@ -155,6 +156,15 @@ The index of the bufferView that contains the image. Use this instead of the ima
 * **Type**: `integer`
 * **Required**: No
 * **Minimum**: ` >= 0`
+
+### image.fraction
+
+A number that must be between zero and one.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+* **Maximum**: ` < 1`
 
 ### image.name
 

--- a/test/test-golden/nested-simple.md
+++ b/test/test-golden/nested-simple.md
@@ -1,0 +1,310 @@
+# Objects
+* [`Buffer View`](#reference-bufferview)
+* [`Extension`](#reference-extension)
+* [`Extras`](#reference-extras)
+* [`Material`](#reference-material)
+   * [`PBR Metallic Roughness`](#reference-material-pbrmetallicroughness)
+* [`nestedTest`](#reference-nestedtest) (root object)
+
+
+---------------------------------------
+<a name="reference-bufferview"></a>
+## Buffer View
+
+A view into a buffer.
+
+**`Buffer View` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**byteOffset**|`integer`|The offset into the buffer in bytes.|No, default: `0`|
+|**byteLength**|`integer`|The length of the bufferView in bytes.| &#x2705; Yes|
+|**byteStride**|`integer`|The stride, in bytes.|No|
+|**target**|`integer`|This is a test of some enums.|No|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
+|**extras**|`extras`|Application-specific data.|No|
+
+Additional properties are allowed.
+
+### bufferView.byteOffset
+
+The offset into the buffer in bytes.
+
+* **Type**: `integer`
+* **Required**: No, default: `0`
+* **Minimum**: ` >= 0`
+
+### bufferView.byteLength &#x2705; 
+
+The length of the bufferView in bytes.
+
+* **Type**: `integer`
+* **Required**: Yes
+* **Minimum**: ` >= 1`
+
+### bufferView.byteStride
+
+The stride, in bytes, between vertex attributes.  This is the detailed description of the property.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 4`
+* **Maximum**: ` <= 252`
+* **Related WebGL functions**: `vertexAttribPointer()` stride parameter
+
+### bufferView.target
+
+This is a test of some enums.
+
+* **Type**: `integer`
+* **Required**: No
+* **Allowed values**:
+   * `34962` ARRAY_BUFFER
+   * `34963` ELEMENT_ARRAY_BUFFER
+* **Related WebGL functions**: `bindBuffer()`
+
+### bufferView.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+### bufferView.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `extension`
+* **Required**: No
+* **Type of each property**: Extension
+
+### bufferView.extras
+
+Application-specific data.
+
+* **Type**: `extras`
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-extension"></a>
+## Extension
+
+Dictionary object with extension-specific objects.
+
+Additional properties are allowed.
+
+
+
+
+---------------------------------------
+<a name="reference-extras"></a>
+## Extras
+
+Application-specific data.
+
+**Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability.
+
+
+
+---------------------------------------
+<a name="reference-material"></a>
+## Material
+
+The material appearance of a primitive.
+
+**`Material` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**name**|`string`|The user-defined name of this object.|No|
+|**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
+|**extras**|`extras`|Application-specific data.|No|
+|**pbrMetallicRoughness**|`material.pbrMetallicRoughness`|A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.|No|
+|**emissiveFactor**|`number` `[3]`|The emissive color of the material.|No, default: `[0,0,0]`|
+|**alphaMode**|`string`|The alpha rendering mode of the material.|No, default: `"OPAQUE"`|
+|**alphaCutoff**|`number`|The alpha cutoff value of the material.|No, default: `0.5`|
+|**doubleSided**|`boolean`|Specifies whether the material is double sided.|No, default: `false`|
+
+Additional properties are allowed.
+
+### material.name
+
+The user-defined name of this object.  This is the detailed description of the property.
+
+* **Type**: `string`
+* **Required**: No
+
+### material.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `extension`
+* **Required**: No
+* **Type of each property**: Extension
+
+### material.extras
+
+Application-specific data.
+
+* **Type**: `extras`
+* **Required**: No
+
+### material.pbrMetallicRoughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
+
+* **Type**: `material.pbrMetallicRoughness`
+* **Required**: No
+
+### material.emissiveFactor
+
+The RGB components of the emissive color of the material. This is the detailed description of the property.
+
+* **Type**: `number` `[3]`
+   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[0,0,0]`
+
+### material.alphaMode
+
+The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture.
+
+* **Type**: `string`
+* **Required**: No, default: `"OPAQUE"`
+* **Allowed values**:
+   * `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
+   * `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
+   * `"BLEND"` The alpha value is used to composite the source and destination areas.
+
+### material.alphaCutoff
+
+Specifies the cutoff threshold when in `MASK` mode. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `0.5`
+* **Minimum**: ` >= 0`
+
+### material.doubleSided
+
+Specifies whether the material is double sided. This is the detailed description of the property.
+
+* **Type**: `boolean`
+* **Required**: No, default: `false`
+
+
+
+
+---------------------------------------
+<a name="reference-material-pbrmetallicroughness"></a>
+## Material PBR Metallic Roughness
+
+A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
+
+**`Material PBR Metallic Roughness` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**baseColorFactor**|`number` `[4]`|The material's base color factor.|No, default: `[1,1,1,1]`|
+|**metallicFactor**|`number`|The metalness of the material.|No, default: `1`|
+|**roughnessFactor**|`number`|The roughness of the material.|No, default: `1`|
+|**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
+|**extras**|`extras`|Application-specific data.|No|
+
+Additional properties are allowed.
+
+### material.pbrMetallicRoughness.baseColorFactor
+
+The RGBA components of the base color of the material. This is the detailed description of the property.
+
+* **Type**: `number` `[4]`
+   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+* **Required**: No, default: `[1,1,1,1]`
+
+### material.pbrMetallicRoughness.metallicFactor
+
+The metalness of the material. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+### material.pbrMetallicRoughness.roughnessFactor
+
+The roughness of the material. This is the detailed description of the property.
+
+* **Type**: `number`
+* **Required**: No, default: `1`
+* **Minimum**: ` >= 0`
+* **Maximum**: ` <= 1`
+
+### material.pbrMetallicRoughness.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `extension`
+* **Required**: No
+* **Type of each property**: Extension
+
+### material.pbrMetallicRoughness.extras
+
+Application-specific data.
+
+* **Type**: `extras`
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-nestedtest"></a>
+## nestedTest
+
+The root object for a nestedTest asset.
+
+**`nestedTest` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**bufferViews**|`bufferView` `[1-*]`|An array of bufferViews.| &#x2705; Yes|
+|**materials**|`material` `[1-*]`|An array of materials.|No|
+|**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
+|**extras**|`extras`|Application-specific data.|No|
+
+Additional properties are allowed.
+
+### nestedTest.bufferViews &#x2705; 
+
+An array of bufferViews.  This is the detailed description of the property.
+
+* **Type**: `bufferView` `[1-*]`
+* **Required**: Yes
+
+### nestedTest.materials
+
+An array of materials.  This is the detailed description of the property.
+
+* **Type**: `material` `[1-*]`
+* **Required**: No
+
+### nestedTest.extensions
+
+Dictionary object with extension-specific objects.
+
+* **Type**: `extension`
+* **Required**: No
+* **Type of each property**: Extension
+
+### nestedTest.extras
+
+Application-specific data.
+
+* **Type**: `extras`
+* **Required**: No
+
+
+
+

--- a/test/test-schemas/example/example.schema.json
+++ b/test/test-schemas/example/example.schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema" : "http://json-schema.org/draft-03/schema",
+    "title" : "example",
+    "type" : "object",
+    "description" : "Example description.",
+    "properties" : {
+        "byteOffset" : {
+            "type" : "integer",
+            "description" : "The offset relative to the start of the buffer in bytes.",
+            "minimum" : 0,
+            "default" : 0
+        },
+        "type" : {
+            "type" : "string",
+            "description" : "Specifies if the elements are scalars, vectors, or matrices.",
+            "enum" : ["SCALAR", "VEC2", "VEC3", "VEC4", "MAT2", "MAT3", "MAT4"],
+            "required" : true
+        }
+    },
+    "additionalProperties" : false
+}

--- a/test/test-schemas/index.json
+++ b/test/test-schemas/index.json
@@ -13,6 +13,6 @@
     }, {
         "name": "nested",
         "path": "nested/nestedTest.schema.json",
-        "ignore": "['nestedchildofrootproperty.schema.json', 'nestedtestproperty.schema.json']"
+        "ignore": "['nestedid.schema.json', 'nestedchildofrootproperty.schema.json', 'nestedtestproperty.schema.json']"
     }]
 }

--- a/test/test-schemas/index.json
+++ b/test/test-schemas/index.json
@@ -1,0 +1,16 @@
+{
+    "options": {
+        "simple.md": "",
+        "simple.adoc": "-m=a",
+        "linked.md": "-l2 -a=cqo -p schema",
+        "linked.adoc": "-l2 -a=cqo -m=a -p schema"
+    },
+    "schemas": [{
+        "name": "example",
+        "path": "example/example.schema.json"
+    }, {
+        "name": "nested",
+        "path": "nested/nestedTest.schema.json",
+        "ignore": "['nestedchildofrootproperty.schema.json', 'nestedtestproperty.schema.json']"
+    }]
+}

--- a/test/test-schemas/index.json
+++ b/test/test-schemas/index.json
@@ -3,7 +3,9 @@
         "simple.md": "",
         "simple.adoc": "-m=a",
         "linked.md": "-l2 -a=cqo -p schema",
-        "linked.adoc": "-l2 -a=cqo -m=a -p schema"
+        "linked.adoc": "-l2 -a=cqo -m=a -p schema",
+        "remote.md": "-l2 -a=cqo -p \"https://www.khronos.org/wetzel/just/testing/schema\"",
+        "remote.adoc": "-l2 -a=cqo -m=a -p \"https://www.khronos.org/wetzel/just/testing/schema\""
     },
     "schemas": [{
         "name": "example",

--- a/test/test-schemas/nested/bufferView.schema.json
+++ b/test/test-schemas/nested/bufferView.schema.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Buffer View",
+    "type": "object",
+    "description": "A view into a buffer.",
+    "allOf": [ { "$ref": "nestedChildOfRootProperty.schema.json" } ],
+    "properties": {
+        "byteOffset": {
+            "type": "integer",
+            "description": "The offset into the buffer in bytes.",
+            "minimum": 0,
+            "default": 0
+        },
+        "byteLength": {
+            "type": "integer",
+            "description": "The length of the bufferView in bytes.",
+            "minimum": 1
+        },
+        "byteStride": {
+            "type": "integer",
+            "description": "The stride, in bytes.",
+            "minimum": 4,
+            "maximum": 252,
+            "multipleOf": 4,
+            "gltf_detailedDescription": "The stride, in bytes, between vertex attributes.  This is the detailed description of the property.",
+            "gltf_webgl": "`vertexAttribPointer()` stride parameter"
+        },
+        "target": {
+            "description": "This is a test of some enums.",
+            "gltf_webgl": "`bindBuffer()`",
+            "anyOf": [
+                {
+                    "enum": [ 34962 ],
+                    "description": "ARRAY_BUFFER",
+                    "type": "integer"
+                },
+                {
+                    "enum": [ 34963 ],
+                    "description": "ELEMENT_ARRAY_BUFFER",
+                    "type": "integer"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        },
+        "name": { },
+        "extensions": { },
+        "extras": { }
+    },
+    "required": [ "byteLength" ]
+}

--- a/test/test-schemas/nested/extension.schema.json
+++ b/test/test-schemas/nested/extension.schema.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Extension",
+    "type": "object",
+    "description": "Dictionary object with extension-specific objects.",
+    "properties": {
+    },
+    "additionalProperties": {
+        "type": "object"
+    }
+}

--- a/test/test-schemas/nested/extras.schema.json
+++ b/test/test-schemas/nested/extras.schema.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Extras",
+    "description": "Application-specific data.",
+    "gltf_sectionDescription": "**Implementation Note:** Although extras may have any type, it is common for applications to store and access custom data as key/value pairs. As best practice, extras should be an Object rather than a primitive value for best portability."
+}

--- a/test/test-schemas/nested/image.schema.json
+++ b/test/test-schemas/nested/image.schema.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Image",
+    "type": "object",
+    "description": "Image data used to create a texture. Image can be referenced by URI or `bufferView` index. `mimeType` is required in the latter case.",
+    "allOf": [ { "$ref": "nestedChildOfRootProperty.schema.json" } ],
+    "properties": {
+        "uri": {
+            "type": "string",
+            "description": "The uri of the image.",
+            "format": "uriref",
+            "gltf_detailedDescription": "The uri of the image.  This is the detailed description of the property.",
+            "gltf_uriType": "image"
+        },
+        "mimeType": {
+            "anyOf": [
+                {
+                    "enum": [ "image/jpeg" ]
+                },
+                {
+                    "enum": [ "image/png" ]
+                },
+                {
+                    "type": "string"
+                }
+            ],
+            "description": "The image's MIME type. Required if `bufferView` is defined."
+        },
+        "bufferView": {
+            "allOf": [ { "$ref": "nestedID.schema.json" } ],
+            "description": "The index of the bufferView that contains the image. Use this instead of the image's uri property."
+        },
+        "name": { },
+        "extensions": { },
+        "extras": { }
+    },
+    "dependencies": {
+        "bufferView": [ "mimeType" ]
+    },
+    "oneOf": [
+        { "required": [ "uri" ] },
+        { "required": [ "bufferView" ] }
+    ]
+}

--- a/test/test-schemas/nested/image.schema.json
+++ b/test/test-schemas/nested/image.schema.json
@@ -30,6 +30,14 @@
             "allOf": [ { "$ref": "nestedID.schema.json" } ],
             "description": "The index of the bufferView that contains the image. Use this instead of the image's uri property."
         },
+        "fraction": {
+            "type": "number",
+            "description": "A number that must be between zero and one.",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "exclusiveMinimum": true,
+            "exclusiveMaximum": true
+        },
         "name": { },
         "extensions": { },
         "extras": { }

--- a/test/test-schemas/nested/material.pbrMetallicRoughness.schema.json
+++ b/test/test-schemas/nested/material.pbrMetallicRoughness.schema.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Material PBR Metallic Roughness",
+    "type": "object",
+    "description": "A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.",
+    "allOf": [ { "$ref": "nestedTestProperty.schema.json" } ],
+    "properties": {
+        "baseColorFactor": {
+            "type": "array",
+            "items": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0
+            },
+            "description": "The material's base color factor.",
+            "default": [ 1.0, 1.0, 1.0, 1.0 ],
+            "minItems": 4,
+            "maxItems": 4,
+            "gltf_detailedDescription": "The RGBA components of the base color of the material. This is the detailed description of the property."
+        },
+        "metallicFactor": {
+            "type": "number",
+            "description": "The metalness of the material.",
+            "default": 1.0,
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "gltf_detailedDescription": "The metalness of the material. This is the detailed description of the property."
+        },
+        "roughnessFactor": {
+            "type": "number",
+            "description": "The roughness of the material.",
+            "default": 1.0,
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "gltf_detailedDescription": "The roughness of the material. This is the detailed description of the property."
+        },
+        "extensions": { },
+        "extras": { }
+    }
+}

--- a/test/test-schemas/nested/material.schema.json
+++ b/test/test-schemas/nested/material.schema.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Material",
+    "type": "object",
+    "description": "The material appearance of a primitive.",
+    "allOf": [ { "$ref": "nestedChildOfRootProperty.schema.json" } ],
+    "properties": {
+        "name": { },
+        "extensions": { },
+        "extras": { },
+        "pbrMetallicRoughness": {
+            "allOf": [ { "$ref": "material.pbrMetallicRoughness.schema.json" } ],
+            "description": "A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply."
+        },
+        "emissiveFactor": {
+            "type": "array",
+            "items": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0
+            },
+            "minItems": 3,
+            "maxItems": 3,
+            "default": [ 0.0, 0.0, 0.0 ],
+            "description": "The emissive color of the material.",
+            "gltf_detailedDescription": "The RGB components of the emissive color of the material. This is the detailed description of the property."
+        },
+        "alphaMode": {
+            "default": "OPAQUE",
+            "description": "The alpha rendering mode of the material.",
+            "gltf_detailedDescription": "The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture.",
+            "anyOf": [
+                {
+                    "enum": [ "OPAQUE" ],
+                    "description": "The alpha value is ignored and the rendered output is fully opaque."
+                },
+                {
+                    "enum": [ "MASK" ],
+                    "description": "The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value."
+                },
+                {
+                    "enum": [ "BLEND" ],
+                    "description": "The alpha value is used to composite the source and destination areas."
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        },
+        "alphaCutoff": {
+            "type": "number",
+            "minimum": 0.0,
+            "default": 0.5,
+            "description": "The alpha cutoff value of the material.",
+            "gltf_detailedDescription": "Specifies the cutoff threshold when in `MASK` mode. This is the detailed description of the property."
+        },
+        "doubleSided": {
+            "type": "boolean",
+            "default": false,
+            "description": "Specifies whether the material is double sided.",
+            "gltf_detailedDescription": "Specifies whether the material is double sided. This is the detailed description of the property."
+        }
+    },
+     "dependencies" : {
+        "alphaCutoff" : ["alphaMode"]
+    }
+}

--- a/test/test-schemas/nested/nestedChildOfRootProperty.schema.json
+++ b/test/test-schemas/nested/nestedChildOfRootProperty.schema.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "nestedTest Child of Root Property",
+    "type": "object",
+    "allOf": [ { "$ref": "nestedTestProperty.schema.json" } ],
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "The user-defined name of this object.",
+            "gltf_detailedDescription": "The user-defined name of this object.  This is the detailed description of the property."
+        }
+    }
+}

--- a/test/test-schemas/nested/nestedID.schema.json
+++ b/test/test-schemas/nested/nestedID.schema.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Nested Test Id",
+    "type": "integer",
+    "minimum": 0
+}

--- a/test/test-schemas/nested/nestedTest.schema.json
+++ b/test/test-schemas/nested/nestedTest.schema.json
@@ -23,6 +23,15 @@
             "minItems": 1,
             "gltf_detailedDescription": "An array of materials.  This is the detailed description of the property."
         },
+        "images": {
+            "type": "array",
+            "description": "An array of images.",
+            "items": {
+                "$ref": "image.schema.json"
+            },
+            "minItems": 1,
+            "gltf_detailedDescription": "An array of images.  This is the detailed description of the property."
+        },
         "version": {
             "type": "string",
             "description": "A version string with a specific pattern.",

--- a/test/test-schemas/nested/nestedTest.schema.json
+++ b/test/test-schemas/nested/nestedTest.schema.json
@@ -23,6 +23,18 @@
             "minItems": 1,
             "gltf_detailedDescription": "An array of materials.  This is the detailed description of the property."
         },
+        "version": {
+            "type": "string",
+            "description": "A version string with a specific pattern.",
+            "pattern": "^[0-9]+\\.[0-9]+$"
+        },
+        "uri": {
+            "type": "string",
+            "description": "A string that should reference a URI.",
+            "format": "uriref",
+            "gltf_detailedDescription": "A string that should reference a URI.  This is the detailed description of the property.",
+            "gltf_uriType": "application"
+        },
         "extensions": { },
         "extras": { }
     },

--- a/test/test-schemas/nested/nestedTest.schema.json
+++ b/test/test-schemas/nested/nestedTest.schema.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "nestedTest",
+    "type": "object",
+    "description": "The root object for a nestedTest asset.",
+    "allOf": [ { "$ref": "nestedTestProperty.schema.json" } ],
+    "properties": {
+        "bufferViews": {
+            "type": "array",
+            "description": "An array of bufferViews.",
+            "items": {
+                "$ref": "bufferView.schema.json"
+            },
+            "minItems": 1,
+            "gltf_detailedDescription": "An array of bufferViews.  This is the detailed description of the property."
+        },
+        "materials": {
+            "type": "array",
+            "description": "An array of materials.",
+            "items": {
+                "$ref": "material.schema.json"
+            },
+            "minItems": 1,
+            "gltf_detailedDescription": "An array of materials.  This is the detailed description of the property."
+        },
+        "extensions": { },
+        "extras": { }
+    },
+    "required": [ "bufferViews" ]
+}

--- a/test/test-schemas/nested/nestedTestProperty.schema.json
+++ b/test/test-schemas/nested/nestedTestProperty.schema.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "nestedTest Property",
+    "type": "object",
+    "properties": {
+        "extensions": {
+            "$ref": "extension.schema.json"
+        },
+        "extras": {
+            "$ref": "extras.schema.json"
+        }
+    }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -48,7 +48,6 @@ describe('wetzel', function () {
 
                     it('should generate ' + outputName, function (done) {
                         const cmd = `${WETZEL_BIN} ${index.options[option]} ${ignore} ${inputPathName} > ${outputPathName}`;
-                        //console.log(cmd);
                         exec(cmd, (error) => {
                             if (error) {
                                 console.error('** ERROR ** ' + error);

--- a/test/test.js
+++ b/test/test.js
@@ -61,6 +61,7 @@ describe('wetzel', function () {
 
                     it('should match golden ' + outputName, function () {
                         let outputText = fs.readFileSync(outputPathName).toString();
+                        assert.ok(outputText.length > 1);
                         let goldenText = fs.readFileSync(goldenPathName).toString();
                         assert.strictEqual(outputText, goldenText);
                     });

--- a/test/test.js
+++ b/test/test.js
@@ -2,11 +2,30 @@
 const fs = require('fs');
 const path = require('path');
 const { exec } = require('child_process');
-//const assert = require('assert');
+const assert = require('assert');
 
 const WETZEL_BIN = 'node ./bin/wetzel.js';
 const SCHEMA_PREFIX = 'test/test-schemas/';
 const OUT_PREFIX = process.env.OUT_PREFIX || 'test/test-output/';
+const GOLDEN_PREFIX = process.env.OUT_PREFIX || 'test/test-golden/';
+
+/**
+ * These tests do not follow typical unit testing guidelines. The final end user never
+ * actually runs wetzel itself, they simply read a document that was produced by wetzel.
+ * As such, we don't bother to probe the innards of wetzel to check if each little API
+ * entry point works. Instead, we have sample schema inputs, and "golden" outputs that
+ * wetzel is expected to produce from those inputs.
+ *
+ * If you hack up the inside of wetzel completely, but the resulting output document
+ * has no diffs at all from what was there before, the tests all pass. If you make an
+ * intentional change to wetzel output, the golden outputs will likewise need to be
+ * updated, revealing the intended change as git diffs. And most importantly, if
+ * some changes to wetzel have unintended concequences for its output formatting,
+ * those will be flagged as test failures. Keep your diffs clean!
+ *
+ * This is basically the strategy that was manually used to test wetzel PRs prior
+ * to any test framework being connected.
+ */
 
 describe('wetzel', function () {
     describe('generated output', function () {
@@ -23,6 +42,7 @@ describe('wetzel', function () {
                 if (index.options.hasOwnProperty(option)) {
                     let outputName = schema.name + '-' + option;
                     let outputPathName = path.join(OUT_PREFIX, outputName);
+                    let goldenPathName = path.join(GOLDEN_PREFIX, outputName);
                     let inputPathName = path.join(SCHEMA_PREFIX, schema.path);
                     let ignore = schema.ignore ? ('-i "' + schema.ignore + '"') : '';
 
@@ -37,6 +57,12 @@ describe('wetzel', function () {
                             }
                             done();
                         });
+                    });
+
+                    it('should match golden ' + outputName, function () {
+                        let outputText = fs.readFileSync(outputPathName).toString();
+                        let goldenText = fs.readFileSync(goldenPathName).toString();
+                        assert.strictEqual(outputText, goldenText);
                     });
                 }
             }

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,45 @@
+/* global describe, it */
+const fs = require('fs');
+const path = require('path');
+const { exec } = require('child_process');
+//const assert = require('assert');
+
+const WETZEL_BIN = 'node ./bin/wetzel.js';
+const SCHEMA_PREFIX = 'test/test-schemas/';
+const OUT_PREFIX = process.env.OUT_PREFIX || 'test/test-output/';
+
+describe('wetzel', function () {
+    describe('generated output', function () {
+        const index = JSON.parse(fs.readFileSync(path.join(SCHEMA_PREFIX, 'index.json')));
+        const numSchemas = index.schemas.length;
+
+        if (!fs.existsSync(OUT_PREFIX)){
+            fs.mkdirSync(OUT_PREFIX);
+        }
+
+        for (let i = 0; i < numSchemas; ++i) {
+            let schema = index.schemas[i];
+            for (let option in index.options) {
+                if (index.options.hasOwnProperty(option)) {
+                    let outputName = schema.name + '-' + option;
+                    let outputPathName = path.join(OUT_PREFIX, outputName);
+                    let inputPathName = path.join(SCHEMA_PREFIX, schema.path);
+                    let ignore = schema.ignore ? ('-i "' + schema.ignore + '"') : '';
+
+                    it('should generate ' + outputName, function (done) {
+                        const cmd = `${WETZEL_BIN} ${index.options[option]} ${ignore} ${inputPathName} > ${outputPathName}`;
+                        //console.log(cmd);
+                        exec(cmd, (error) => {
+                            if (error) {
+                                console.error('** ERROR ** ' + error);
+                                done(error);
+                                return;
+                            }
+                            done();
+                        });
+                    });
+                }
+            }
+        }
+    });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -6,8 +6,8 @@ const assert = require('assert');
 
 const WETZEL_BIN = 'node ./bin/wetzel.js';
 const SCHEMA_PREFIX = 'test/test-schemas/';
+const GOLDEN_PREFIX = 'test/test-golden/';
 const OUT_PREFIX = process.env.OUT_PREFIX || 'test/test-output/';
-const GOLDEN_PREFIX = process.env.OUT_PREFIX || 'test/test-golden/';
 
 /**
  * These tests do not follow typical unit testing guidelines. The final end user never


### PR DESCRIPTION
Added a minimal testing hookup to wetzel.

These tests do not follow typical unit testing guidelines. The final end user never actually runs wetzel itself, they simply read a document that was produced by wetzel. As such, we don't bother to probe the innards of wetzel to check if each little API entry point works. Instead, we have sample schema inputs, and "golden" outputs that wetzel is expected to produce from those inputs.

If you hack up the inside of wetzel completely, but the resulting output document has no diffs at all from what was there before, the tests all pass. If you make an intentional change to wetzel output, the golden outputs will likewise need to be updated, revealing the intended change as git diffs. And most importantly, if some changes to wetzel have unintended concequences for its output formatting, those will be flagged as test failures. Keep your diffs clean!

This is basically the strategy that was manually used to test wetzel PRs prior to any test framework being connected.
