### PR TITLE
Option to disable TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Options:
 * The `-p` option lets you specify the relative path that should be used when referencing the schema, relative to where you store the documentation.
 * The `-s` option lets you specify the path string that should be used when loading the schema reference paths.
 * The `-m` option controls the output style mode. The default is `Markdown`, use `-m=a` for `AsciiDoctor` mode.
+* The `-n` option will skip writing a Table of Contents.
 * The `-w` option will suppress any warnings about potential documentation problems that wetzel normally prints by default.
 * The `-d` option lets you specify the root filename that will be used for writing intermediate wetzel artifacts that are useful when doing wetzel development.
 * The `-a` option will attempt to aggressively auto-link referenced type names in descriptions between each other.  If it's too agressive, you can add `=cqo` so that it only attempts to auto-link type names that are within "code-quotes only" (cqo) (e.g.: ``typeName``)

--- a/bin/wetzel.js
+++ b/bin/wetzel.js
@@ -14,6 +14,7 @@ if (!defined(argv._[0]) || defined(argv.h) || defined(argv.help)) {
         '  -p,  --schemaPath         The path string that should be used when generating the schema reference paths.\n' +
         '  -s,  --searchPath         The path string that should be used when loading the schema reference paths.\n' +
         '  -m,  --outputMode         The output mode, Markdown (the default) or AsciiDoctor (a).' +
+        '  -n,  --noTOC              Skip writing the Table of Contents.' +
         '  -a,  --autoLink           Aggressively auto-inter-link types referenced in descriptions.\n' +
         '                                Add =cqo to auto-link types that are in code-quotes only.\n' +
         '  -i                        An array of schema filenames (no paths) that should not get their own\n' +
@@ -65,6 +66,7 @@ process.stdout.write(generateMarkdown({
     fileName: path.basename(filepath),
     searchPath: searchPath,
     styleMode: styleModeArgument,
+    writeTOC: !defaultValue(defaultValue(argv.n, argv.noTOC), false),
     headerLevel: defaultValue(defaultValue(argv.l, argv.headerLevel), 1),
     schemaRelativeBasePath: defaultValue(defaultValue(argv.p, argv.schemaPath), null),
     debug: defaultValue(defaultValue(argv.d, argv.debug), null),

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -197,9 +197,6 @@ function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, sche
                 schemaRelativeBasePath += '/';
             }
             md += style.bulletItem(style.bold('JSON schema') + ': ' + style.getLinkMarkdown(fileName, schemaRelativeBasePath.replace(/\\/g, '/') + fileName)) + '\n';
-
-            // TODO: figure out how to auto-determine example reference
-            //* **Example**: [bufferViews.json](schema/examples/bufferViews.json)
         }
 
         // Render section for each property
@@ -322,6 +319,11 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
             var format = property.format;
             if (defined(format)) {
                 md += style.bulletItem(style.propertyDetails('Format') + ': ' + format, 0);
+            }
+
+            var pattern = property.pattern;
+            if (defined(pattern)) {
+                md += style.bulletItem(style.propertyDetails('Pattern') + ': ' + style.minMax(pattern), 0);
             }
 
             var minLength = property.minLength;

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -53,7 +53,9 @@ function generateMarkdown(options) {
     // We need the reverse-sorted version so that when we do type searching we find the longest type first.
     var orderedTypesDescending = sortObject(resolved.referencedSchemas, false);
 
-    md += getTableOfContentsMarkdown(schema, orderedTypes, options.headerLevel);
+    if (options.writeTOC) {
+        md += getTableOfContentsMarkdown(schema, orderedTypes, options.headerLevel);
+    }
 
     for (let title in orderedTypes) {
         md += '\n\n';

--- a/test/test-golden/example-remote.adoc
+++ b/test/test-golden/example-remote.adoc
@@ -1,10 +1,8 @@
-== Objects
-* link:#reference-example[`example`] (root object)
 
 
 '''
 [#reference-example]
-=== example
+== example
 
 Example description.
 
@@ -28,7 +26,7 @@ Additional properties are not allowed.
 
 * **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/example.schema.json[example.schema.json]
 
-==== example.byteOffset
+=== example.byteOffset
 
 The offset relative to the start of the buffer in bytes.
 
@@ -36,7 +34,7 @@ The offset relative to the start of the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: `&gt;= 0`
 
-==== example.type &#x2705; 
+=== example.type &#x2705; 
 
 Specifies if the elements are scalars, vectors, or matrices.
 

--- a/test/test-golden/example-remote.md
+++ b/test/test-golden/example-remote.md
@@ -1,10 +1,8 @@
-## Objects
-* [`example`](#reference-example) (root object)
 
 
 ---------------------------------------
 <a name="reference-example"></a>
-### example
+## example
 
 Example description.
 
@@ -19,7 +17,7 @@ Additional properties are not allowed.
 
 * **JSON schema**: [example.schema.json](https://www.khronos.org/wetzel/just/testing/schema/example.schema.json)
 
-#### example.byteOffset
+### example.byteOffset
 
 The offset relative to the start of the buffer in bytes.
 
@@ -27,7 +25,7 @@ The offset relative to the start of the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: ` >= 0`
 
-#### example.type &#x2705; 
+### example.type &#x2705; 
 
 Specifies if the elements are scalars, vectors, or matrices.
 

--- a/test/test-golden/nested-linked.adoc
+++ b/test/test-golden/nested-linked.adoc
@@ -540,6 +540,7 @@ A version string with a specific pattern.
 
 * **Type**: `string`
 * **Required**: No
+* **Pattern**: `^[0-9]+\.[0-9]+$`
 
 ==== nestedTest.uri
 

--- a/test/test-golden/nested-linked.md
+++ b/test/test-golden/nested-linked.md
@@ -399,6 +399,7 @@ A version string with a specific pattern.
 
 * **Type**: `string`
 * **Required**: No
+* **Pattern**: `^[0-9]+\.[0-9]+$`
 
 #### nestedTest.uri
 

--- a/test/test-golden/nested-remote.adoc
+++ b/test/test-golden/nested-remote.adoc
@@ -532,6 +532,7 @@ A version string with a specific pattern.
 
 * **Type**: `string`
 * **Required**: No
+* **Pattern**: `^[0-9]+\.[0-9]+$`
 
 === nestedTest.uri
 

--- a/test/test-golden/nested-remote.adoc
+++ b/test/test-golden/nested-remote.adoc
@@ -1,16 +1,8 @@
-== Objects
-* link:#reference-bufferview[`Buffer View`]
-* link:#reference-extension[`Extension`]
-* link:#reference-extras[`Extras`]
-* link:#reference-image[`Image`]
-* link:#reference-material[`Material`]
-** link:#reference-material-pbrmetallicroughness[`PBR Metallic Roughness`]
-* link:#reference-nestedtest[`nestedTest`] (root object)
 
 
 '''
 [#reference-bufferview]
-=== Buffer View
+== Buffer View
 
 A view into a buffer.
 
@@ -59,7 +51,7 @@ Additional properties are allowed.
 
 * **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/bufferView.schema.json[bufferView.schema.json]
 
-==== bufferView.byteOffset
+=== bufferView.byteOffset
 
 The offset into the buffer in bytes.
 
@@ -67,7 +59,7 @@ The offset into the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: `&gt;= 0`
 
-==== bufferView.byteLength &#x2705; 
+=== bufferView.byteLength &#x2705; 
 
 The length of the bufferView in bytes.
 
@@ -75,7 +67,7 @@ The length of the bufferView in bytes.
 * **Required**: Yes
 * **Minimum**: `&gt;= 1`
 
-==== bufferView.byteStride
+=== bufferView.byteStride
 
 The stride, in bytes, between vertex attributes.  This is the detailed description of the property.
 
@@ -85,7 +77,7 @@ The stride, in bytes, between vertex attributes.  This is the detailed descripti
 * **Maximum**: `&lt;= 252`
 * **Related WebGL functions**: `vertexAttribPointer()` stride parameter
 
-==== bufferView.target
+=== bufferView.target
 
 This is a test of some enums.
 
@@ -96,14 +88,14 @@ This is a test of some enums.
 ** `34963` ELEMENT_ARRAY_BUFFER
 * **Related WebGL functions**: `bindBuffer()`
 
-==== bufferView.name
+=== bufferView.name
 
 The user-defined name of this object.  This is the detailed description of the property.
 
 * **Type**: `string`
 * **Required**: No
 
-==== bufferView.extensions
+=== bufferView.extensions
 
 Dictionary object with extension-specific objects.
 
@@ -111,7 +103,7 @@ Dictionary object with extension-specific objects.
 * **Required**: No
 * **Type of each property**: Extension
 
-==== bufferView.extras
+=== bufferView.extras
 
 Application-specific data.
 
@@ -123,7 +115,7 @@ Application-specific data.
 
 '''
 [#reference-extension]
-=== Extension
+== Extension
 
 Dictionary object with extension-specific objects.
 
@@ -136,7 +128,7 @@ Additional properties are allowed.
 
 '''
 [#reference-extras]
-=== Extras
+== Extras
 
 Application-specific data.
 
@@ -146,7 +138,7 @@ Application-specific data.
 
 '''
 [#reference-image]
-=== Image
+== Image
 
 Image data used to create a texture. Image can be referenced by URI or `bufferView` index. `mimeType` is required in the latter case.
 
@@ -195,7 +187,7 @@ Additional properties are allowed.
 
 * **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/image.schema.json[image.schema.json]
 
-==== image.uri
+=== image.uri
 
 The uri of the image.  This is the detailed description of the property.
 
@@ -203,7 +195,7 @@ The uri of the image.  This is the detailed description of the property.
 * **Required**: No
 * **Format**: uriref
 
-==== image.mimeType
+=== image.mimeType
 
 The image's MIME type. Required if `bufferView` is defined.
 
@@ -213,7 +205,7 @@ The image's MIME type. Required if `bufferView` is defined.
 ** `"image/jpeg"`
 ** `"image/png"`
 
-==== image.bufferView
+=== image.bufferView
 
 The index of the bufferView that contains the image. Use this instead of the image's uri property.
 
@@ -221,7 +213,7 @@ The index of the bufferView that contains the image. Use this instead of the ima
 * **Required**: No
 * **Minimum**: `&gt;= 0`
 
-==== image.fraction
+=== image.fraction
 
 A number that must be between zero and one.
 
@@ -230,14 +222,14 @@ A number that must be between zero and one.
 * **Minimum**: `&gt; 0`
 * **Maximum**: `&lt; 1`
 
-==== image.name
+=== image.name
 
 The user-defined name of this object.  This is the detailed description of the property.
 
 * **Type**: `string`
 * **Required**: No
 
-==== image.extensions
+=== image.extensions
 
 Dictionary object with extension-specific objects.
 
@@ -245,7 +237,7 @@ Dictionary object with extension-specific objects.
 * **Required**: No
 * **Type of each property**: Extension
 
-==== image.extras
+=== image.extras
 
 Application-specific data.
 
@@ -257,7 +249,7 @@ Application-specific data.
 
 '''
 [#reference-material]
-=== Material
+== Material
 
 The material appearance of a primitive.
 
@@ -311,14 +303,14 @@ Additional properties are allowed.
 
 * **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/material.schema.json[material.schema.json]
 
-==== material.name
+=== material.name
 
 The user-defined name of this object.  This is the detailed description of the property.
 
 * **Type**: `string`
 * **Required**: No
 
-==== material.extensions
+=== material.extensions
 
 Dictionary object with extension-specific objects.
 
@@ -326,21 +318,21 @@ Dictionary object with extension-specific objects.
 * **Required**: No
 * **Type of each property**: Extension
 
-==== material.extras
+=== material.extras
 
 Application-specific data.
 
 * **Type**: link:#reference-extras[`extras`]
 * **Required**: No
 
-==== material.pbrMetallicRoughness
+=== material.pbrMetallicRoughness
 
 A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
 
 * **Type**: link:#reference-material-pbrmetallicroughness[`material.pbrMetallicRoughness`]
 * **Required**: No
 
-==== material.emissiveFactor
+=== material.emissiveFactor
 
 The RGB components of the emissive color of the material. This is the detailed description of the property.
 
@@ -348,7 +340,7 @@ The RGB components of the emissive color of the material. This is the detailed d
 ** Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
 * **Required**: No, default: `[0,0,0]`
 
-==== material.alphaMode
+=== material.alphaMode
 
 The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture.
 
@@ -359,7 +351,7 @@ The material's alpha rendering mode enumeration specifying the interpretation of
 ** `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
 ** `"BLEND"` The alpha value is used to composite the source and destination areas.
 
-==== material.alphaCutoff
+=== material.alphaCutoff
 
 Specifies the cutoff threshold when in `MASK` mode. This is the detailed description of the property.
 
@@ -367,7 +359,7 @@ Specifies the cutoff threshold when in `MASK` mode. This is the detailed descrip
 * **Required**: No, default: `0.5`
 * **Minimum**: `&gt;= 0`
 
-==== material.doubleSided
+=== material.doubleSided
 
 Specifies whether the material is double sided. This is the detailed description of the property.
 
@@ -379,7 +371,7 @@ Specifies whether the material is double sided. This is the detailed description
 
 '''
 [#reference-material-pbrmetallicroughness]
-=== Material PBR Metallic Roughness
+== Material PBR Metallic Roughness
 
 A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
 
@@ -418,7 +410,7 @@ Additional properties are allowed.
 
 * **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/material.pbrMetallicRoughness.schema.json[material.pbrMetallicRoughness.schema.json]
 
-==== material.pbrMetallicRoughness.baseColorFactor
+=== material.pbrMetallicRoughness.baseColorFactor
 
 The RGBA components of the base color of the material. This is the detailed description of the property.
 
@@ -426,7 +418,7 @@ The RGBA components of the base color of the material. This is the detailed desc
 ** Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
 * **Required**: No, default: `[1,1,1,1]`
 
-==== material.pbrMetallicRoughness.metallicFactor
+=== material.pbrMetallicRoughness.metallicFactor
 
 The metalness of the material. This is the detailed description of the property.
 
@@ -435,7 +427,7 @@ The metalness of the material. This is the detailed description of the property.
 * **Minimum**: `&gt;= 0`
 * **Maximum**: `&lt;= 1`
 
-==== material.pbrMetallicRoughness.roughnessFactor
+=== material.pbrMetallicRoughness.roughnessFactor
 
 The roughness of the material. This is the detailed description of the property.
 
@@ -444,7 +436,7 @@ The roughness of the material. This is the detailed description of the property.
 * **Minimum**: `&gt;= 0`
 * **Maximum**: `&lt;= 1`
 
-==== material.pbrMetallicRoughness.extensions
+=== material.pbrMetallicRoughness.extensions
 
 Dictionary object with extension-specific objects.
 
@@ -452,7 +444,7 @@ Dictionary object with extension-specific objects.
 * **Required**: No
 * **Type of each property**: Extension
 
-==== material.pbrMetallicRoughness.extras
+=== material.pbrMetallicRoughness.extras
 
 Application-specific data.
 
@@ -464,7 +456,7 @@ Application-specific data.
 
 '''
 [#reference-nestedtest]
-=== nestedTest
+== nestedTest
 
 The root object for a nestedTest asset.
 
@@ -513,35 +505,35 @@ Additional properties are allowed.
 
 * **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/nestedTest.schema.json[nestedTest.schema.json]
 
-==== nestedTest.bufferViews &#x2705; 
+=== nestedTest.bufferViews &#x2705; 
 
 An array of bufferViews.  This is the detailed description of the property.
 
 * **Type**: link:#reference-bufferview[`bufferView`] `[1-*]`
 * **Required**: Yes
 
-==== nestedTest.materials
+=== nestedTest.materials
 
 An array of materials.  This is the detailed description of the property.
 
 * **Type**: link:#reference-material[`material`] `[1-*]`
 * **Required**: No
 
-==== nestedTest.images
+=== nestedTest.images
 
 An array of images.  This is the detailed description of the property.
 
 * **Type**: link:#reference-image[`image`] `[1-*]`
 * **Required**: No
 
-==== nestedTest.version
+=== nestedTest.version
 
 A version string with a specific pattern.
 
 * **Type**: `string`
 * **Required**: No
 
-==== nestedTest.uri
+=== nestedTest.uri
 
 A string that should reference a URI.  This is the detailed description of the property.
 
@@ -549,7 +541,7 @@ A string that should reference a URI.  This is the detailed description of the p
 * **Required**: No
 * **Format**: uriref
 
-==== nestedTest.extensions
+=== nestedTest.extensions
 
 Dictionary object with extension-specific objects.
 
@@ -557,7 +549,7 @@ Dictionary object with extension-specific objects.
 * **Required**: No
 * **Type of each property**: Extension
 
-==== nestedTest.extras
+=== nestedTest.extras
 
 Application-specific data.
 

--- a/test/test-golden/nested-remote.md
+++ b/test/test-golden/nested-remote.md
@@ -391,6 +391,7 @@ A version string with a specific pattern.
 
 * **Type**: `string`
 * **Required**: No
+* **Pattern**: `^[0-9]+\.[0-9]+$`
 
 ### nestedTest.uri
 

--- a/test/test-golden/nested-remote.md
+++ b/test/test-golden/nested-remote.md
@@ -1,16 +1,8 @@
-## Objects
-* [`Buffer View`](#reference-bufferview)
-* [`Extension`](#reference-extension)
-* [`Extras`](#reference-extras)
-* [`Image`](#reference-image)
-* [`Material`](#reference-material)
-   * [`PBR Metallic Roughness`](#reference-material-pbrmetallicroughness)
-* [`nestedTest`](#reference-nestedtest) (root object)
 
 
 ---------------------------------------
 <a name="reference-bufferview"></a>
-### Buffer View
+## Buffer View
 
 A view into a buffer.
 
@@ -30,7 +22,7 @@ Additional properties are allowed.
 
 * **JSON schema**: [bufferView.schema.json](https://www.khronos.org/wetzel/just/testing/schema/bufferView.schema.json)
 
-#### bufferView.byteOffset
+### bufferView.byteOffset
 
 The offset into the buffer in bytes.
 
@@ -38,7 +30,7 @@ The offset into the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: ` >= 0`
 
-#### bufferView.byteLength &#x2705; 
+### bufferView.byteLength &#x2705; 
 
 The length of the bufferView in bytes.
 
@@ -46,7 +38,7 @@ The length of the bufferView in bytes.
 * **Required**: Yes
 * **Minimum**: ` >= 1`
 
-#### bufferView.byteStride
+### bufferView.byteStride
 
 The stride, in bytes, between vertex attributes.  This is the detailed description of the property.
 
@@ -56,7 +48,7 @@ The stride, in bytes, between vertex attributes.  This is the detailed descripti
 * **Maximum**: ` <= 252`
 * **Related WebGL functions**: `vertexAttribPointer()` stride parameter
 
-#### bufferView.target
+### bufferView.target
 
 This is a test of some enums.
 
@@ -67,14 +59,14 @@ This is a test of some enums.
    * `34963` ELEMENT_ARRAY_BUFFER
 * **Related WebGL functions**: `bindBuffer()`
 
-#### bufferView.name
+### bufferView.name
 
 The user-defined name of this object.  This is the detailed description of the property.
 
 * **Type**: `string`
 * **Required**: No
 
-#### bufferView.extensions
+### bufferView.extensions
 
 Dictionary object with extension-specific objects.
 
@@ -82,7 +74,7 @@ Dictionary object with extension-specific objects.
 * **Required**: No
 * **Type of each property**: Extension
 
-#### bufferView.extras
+### bufferView.extras
 
 Application-specific data.
 
@@ -94,7 +86,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-extension"></a>
-### Extension
+## Extension
 
 Dictionary object with extension-specific objects.
 
@@ -107,7 +99,7 @@ Additional properties are allowed.
 
 ---------------------------------------
 <a name="reference-extras"></a>
-### Extras
+## Extras
 
 Application-specific data.
 
@@ -117,7 +109,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-image"></a>
-### Image
+## Image
 
 Image data used to create a texture. Image can be referenced by URI or `bufferView` index. `mimeType` is required in the latter case.
 
@@ -137,7 +129,7 @@ Additional properties are allowed.
 
 * **JSON schema**: [image.schema.json](https://www.khronos.org/wetzel/just/testing/schema/image.schema.json)
 
-#### image.uri
+### image.uri
 
 The uri of the image.  This is the detailed description of the property.
 
@@ -145,7 +137,7 @@ The uri of the image.  This is the detailed description of the property.
 * **Required**: No
 * **Format**: uriref
 
-#### image.mimeType
+### image.mimeType
 
 The image's MIME type. Required if `bufferView` is defined.
 
@@ -155,7 +147,7 @@ The image's MIME type. Required if `bufferView` is defined.
    * `"image/jpeg"`
    * `"image/png"`
 
-#### image.bufferView
+### image.bufferView
 
 The index of the bufferView that contains the image. Use this instead of the image's uri property.
 
@@ -163,7 +155,7 @@ The index of the bufferView that contains the image. Use this instead of the ima
 * **Required**: No
 * **Minimum**: ` >= 0`
 
-#### image.fraction
+### image.fraction
 
 A number that must be between zero and one.
 
@@ -172,14 +164,14 @@ A number that must be between zero and one.
 * **Minimum**: ` > 0`
 * **Maximum**: ` < 1`
 
-#### image.name
+### image.name
 
 The user-defined name of this object.  This is the detailed description of the property.
 
 * **Type**: `string`
 * **Required**: No
 
-#### image.extensions
+### image.extensions
 
 Dictionary object with extension-specific objects.
 
@@ -187,7 +179,7 @@ Dictionary object with extension-specific objects.
 * **Required**: No
 * **Type of each property**: Extension
 
-#### image.extras
+### image.extras
 
 Application-specific data.
 
@@ -199,7 +191,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-material"></a>
-### Material
+## Material
 
 The material appearance of a primitive.
 
@@ -220,14 +212,14 @@ Additional properties are allowed.
 
 * **JSON schema**: [material.schema.json](https://www.khronos.org/wetzel/just/testing/schema/material.schema.json)
 
-#### material.name
+### material.name
 
 The user-defined name of this object.  This is the detailed description of the property.
 
 * **Type**: `string`
 * **Required**: No
 
-#### material.extensions
+### material.extensions
 
 Dictionary object with extension-specific objects.
 
@@ -235,21 +227,21 @@ Dictionary object with extension-specific objects.
 * **Required**: No
 * **Type of each property**: Extension
 
-#### material.extras
+### material.extras
 
 Application-specific data.
 
 * **Type**: [`extras`](#reference-extras)
 * **Required**: No
 
-#### material.pbrMetallicRoughness
+### material.pbrMetallicRoughness
 
 A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology. When not specified, all the default values of `pbrMetallicRoughness` apply.
 
 * **Type**: [`material.pbrMetallicRoughness`](#reference-material-pbrmetallicroughness)
 * **Required**: No
 
-#### material.emissiveFactor
+### material.emissiveFactor
 
 The RGB components of the emissive color of the material. This is the detailed description of the property.
 
@@ -257,7 +249,7 @@ The RGB components of the emissive color of the material. This is the detailed d
    * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
 * **Required**: No, default: `[0,0,0]`
 
-#### material.alphaMode
+### material.alphaMode
 
 The material's alpha rendering mode enumeration specifying the interpretation of the alpha value of the main factor and texture.
 
@@ -268,7 +260,7 @@ The material's alpha rendering mode enumeration specifying the interpretation of
    * `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
    * `"BLEND"` The alpha value is used to composite the source and destination areas.
 
-#### material.alphaCutoff
+### material.alphaCutoff
 
 Specifies the cutoff threshold when in `MASK` mode. This is the detailed description of the property.
 
@@ -276,7 +268,7 @@ Specifies the cutoff threshold when in `MASK` mode. This is the detailed descrip
 * **Required**: No, default: `0.5`
 * **Minimum**: ` >= 0`
 
-#### material.doubleSided
+### material.doubleSided
 
 Specifies whether the material is double sided. This is the detailed description of the property.
 
@@ -288,7 +280,7 @@ Specifies whether the material is double sided. This is the detailed description
 
 ---------------------------------------
 <a name="reference-material-pbrmetallicroughness"></a>
-### Material PBR Metallic Roughness
+## Material PBR Metallic Roughness
 
 A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.
 
@@ -306,7 +298,7 @@ Additional properties are allowed.
 
 * **JSON schema**: [material.pbrMetallicRoughness.schema.json](https://www.khronos.org/wetzel/just/testing/schema/material.pbrMetallicRoughness.schema.json)
 
-#### material.pbrMetallicRoughness.baseColorFactor
+### material.pbrMetallicRoughness.baseColorFactor
 
 The RGBA components of the base color of the material. This is the detailed description of the property.
 
@@ -314,7 +306,7 @@ The RGBA components of the base color of the material. This is the detailed desc
    * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
 * **Required**: No, default: `[1,1,1,1]`
 
-#### material.pbrMetallicRoughness.metallicFactor
+### material.pbrMetallicRoughness.metallicFactor
 
 The metalness of the material. This is the detailed description of the property.
 
@@ -323,7 +315,7 @@ The metalness of the material. This is the detailed description of the property.
 * **Minimum**: ` >= 0`
 * **Maximum**: ` <= 1`
 
-#### material.pbrMetallicRoughness.roughnessFactor
+### material.pbrMetallicRoughness.roughnessFactor
 
 The roughness of the material. This is the detailed description of the property.
 
@@ -332,7 +324,7 @@ The roughness of the material. This is the detailed description of the property.
 * **Minimum**: ` >= 0`
 * **Maximum**: ` <= 1`
 
-#### material.pbrMetallicRoughness.extensions
+### material.pbrMetallicRoughness.extensions
 
 Dictionary object with extension-specific objects.
 
@@ -340,7 +332,7 @@ Dictionary object with extension-specific objects.
 * **Required**: No
 * **Type of each property**: Extension
 
-#### material.pbrMetallicRoughness.extras
+### material.pbrMetallicRoughness.extras
 
 Application-specific data.
 
@@ -352,7 +344,7 @@ Application-specific data.
 
 ---------------------------------------
 <a name="reference-nestedtest"></a>
-### nestedTest
+## nestedTest
 
 The root object for a nestedTest asset.
 
@@ -372,35 +364,35 @@ Additional properties are allowed.
 
 * **JSON schema**: [nestedTest.schema.json](https://www.khronos.org/wetzel/just/testing/schema/nestedTest.schema.json)
 
-#### nestedTest.bufferViews &#x2705; 
+### nestedTest.bufferViews &#x2705; 
 
 An array of bufferViews.  This is the detailed description of the property.
 
 * **Type**: [`bufferView`](#reference-bufferview) `[1-*]`
 * **Required**: Yes
 
-#### nestedTest.materials
+### nestedTest.materials
 
 An array of materials.  This is the detailed description of the property.
 
 * **Type**: [`material`](#reference-material) `[1-*]`
 * **Required**: No
 
-#### nestedTest.images
+### nestedTest.images
 
 An array of images.  This is the detailed description of the property.
 
 * **Type**: [`image`](#reference-image) `[1-*]`
 * **Required**: No
 
-#### nestedTest.version
+### nestedTest.version
 
 A version string with a specific pattern.
 
 * **Type**: `string`
 * **Required**: No
 
-#### nestedTest.uri
+### nestedTest.uri
 
 A string that should reference a URI.  This is the detailed description of the property.
 
@@ -408,7 +400,7 @@ A string that should reference a URI.  This is the detailed description of the p
 * **Required**: No
 * **Format**: uriref
 
-#### nestedTest.extensions
+### nestedTest.extensions
 
 Dictionary object with extension-specific objects.
 
@@ -416,7 +408,7 @@ Dictionary object with extension-specific objects.
 * **Required**: No
 * **Type of each property**: Extension
 
-#### nestedTest.extras
+### nestedTest.extras
 
 Application-specific data.
 

--- a/test/test-golden/nested-simple.adoc
+++ b/test/test-golden/nested-simple.adoc
@@ -528,6 +528,7 @@ A version string with a specific pattern.
 
 * **Type**: `string`
 * **Required**: No
+* **Pattern**: `^[0-9]+\.[0-9]+$`
 
 === nestedTest.uri
 

--- a/test/test-golden/nested-simple.md
+++ b/test/test-golden/nested-simple.md
@@ -387,6 +387,7 @@ A version string with a specific pattern.
 
 * **Type**: `string`
 * **Required**: No
+* **Pattern**: `^[0-9]+\.[0-9]+$`
 
 ### nestedTest.uri
 

--- a/test/test-schemas/index.json
+++ b/test/test-schemas/index.json
@@ -4,8 +4,8 @@
         "simple.adoc": "-m=a",
         "linked.md": "-l2 -a=cqo -p schema",
         "linked.adoc": "-l2 -a=cqo -m=a -p schema",
-        "remote.md": "-l2 -a=cqo -p \"https://www.khronos.org/wetzel/just/testing/schema\"",
-        "remote.adoc": "-l2 -a=cqo -m=a -p \"https://www.khronos.org/wetzel/just/testing/schema\""
+        "remote.md": "-n -a=cqo -p \"https://www.khronos.org/wetzel/just/testing/schema\"",
+        "remote.adoc": "-n -a=cqo -m=a -p \"https://www.khronos.org/wetzel/just/testing/schema\""
     },
     "schemas": [{
         "name": "example",


### PR DESCRIPTION
Added an option to turn off the table of contents.  AsciiDoctor in particular will build its own, so wetzel shouldn't always generate one.

Also added the pattern display:  Fixes #32.
