### PR TITLE
Settle down checkmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Example description.
 |   |Type|Description|Required|
 |---|---|---|---|
 |**byteOffset**|`integer`|The offset relative to the start of the buffer in bytes.|No, default: `0`|
-|**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &#x2705; Yes|
+|**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &check; Yes|
 
 Additional properties are not allowed.
 
@@ -65,7 +65,7 @@ The offset relative to the start of the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: ` >= 0`
 
-### example.type &#x2705; 
+### example.type
 
 Specifies if the elements are scalars, vectors, or matrices.
 

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -262,7 +262,7 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
                 variableTitle = title;
             }
 
-            md += headerMd + ' ' + variableTitle + '.' + name + (summary.required === 'Yes' ? style.requiredIcon : '') + '\n\n';
+            md += headerMd + ' ' + variableTitle + '.' + name + '\n\n';
 
             // TODO: Add plugin point for custom JSON schema properties like gltf_*
             var detailedDescription = autoLinkDescription(property.gltf_detailedDescription, knownTypes, autoLink);

--- a/lib/style.js
+++ b/lib/style.js
@@ -123,7 +123,7 @@ module.exports = {
     /**
     * @property {string} The markdown string used for displaying the icon used to indicate a value is required.
     */
-    requiredIcon: ' &#x2705; '
+    requiredIcon: ' &check; '
 };
 
 const REFERENCE = "reference-";

--- a/test/test-golden/example-embed.adoc
+++ b/test/test-golden/example-embed.adoc
@@ -18,7 +18,7 @@ Example description.
 |**type**
 |`string`
 |Specifies if the elements are scalars, vectors, or matrices.
-| &#x2705; Yes
+| &check; Yes
 
 |===
 
@@ -34,7 +34,7 @@ The offset relative to the start of the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: `&gt;= 0`
 
-=== example.type &#x2705; 
+=== example.type
 
 Specifies if the elements are scalars, vectors, or matrices.
 

--- a/test/test-golden/example-linked.adoc
+++ b/test/test-golden/example-linked.adoc
@@ -20,7 +20,7 @@ Example description.
 |**type**
 |`string`
 |Specifies if the elements are scalars, vectors, or matrices.
-| &#x2705; Yes
+| &check; Yes
 
 |===
 
@@ -36,7 +36,7 @@ The offset relative to the start of the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: `&gt;= 0`
 
-==== example.type &#x2705; 
+==== example.type
 
 Specifies if the elements are scalars, vectors, or matrices.
 

--- a/test/test-golden/example-linked.md
+++ b/test/test-golden/example-linked.md
@@ -13,7 +13,7 @@ Example description.
 |   |Type|Description|Required|
 |---|---|---|---|
 |**byteOffset**|`integer`|The offset relative to the start of the buffer in bytes.|No, default: `0`|
-|**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &#x2705; Yes|
+|**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &check; Yes|
 
 Additional properties are not allowed.
 
@@ -27,7 +27,7 @@ The offset relative to the start of the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: ` >= 0`
 
-#### example.type &#x2705; 
+#### example.type
 
 Specifies if the elements are scalars, vectors, or matrices.
 

--- a/test/test-golden/example-remote.adoc
+++ b/test/test-golden/example-remote.adoc
@@ -18,7 +18,7 @@ Example description.
 |**type**
 |`string`
 |Specifies if the elements are scalars, vectors, or matrices.
-| &#x2705; Yes
+| &check; Yes
 
 |===
 
@@ -34,7 +34,7 @@ The offset relative to the start of the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: `&gt;= 0`
 
-=== example.type &#x2705; 
+=== example.type
 
 Specifies if the elements are scalars, vectors, or matrices.
 

--- a/test/test-golden/example-remote.md
+++ b/test/test-golden/example-remote.md
@@ -11,7 +11,7 @@ Example description.
 |   |Type|Description|Required|
 |---|---|---|---|
 |**byteOffset**|`integer`|The offset relative to the start of the buffer in bytes.|No, default: `0`|
-|**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &#x2705; Yes|
+|**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &check; Yes|
 
 Additional properties are not allowed.
 
@@ -25,7 +25,7 @@ The offset relative to the start of the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: ` >= 0`
 
-### example.type &#x2705; 
+### example.type
 
 Specifies if the elements are scalars, vectors, or matrices.
 

--- a/test/test-golden/example-simple.adoc
+++ b/test/test-golden/example-simple.adoc
@@ -20,7 +20,7 @@ Example description.
 |**type**
 |`string`
 |Specifies if the elements are scalars, vectors, or matrices.
-| &#x2705; Yes
+| &check; Yes
 
 |===
 
@@ -34,7 +34,7 @@ The offset relative to the start of the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: `&gt;= 0`
 
-=== example.type &#x2705; 
+=== example.type
 
 Specifies if the elements are scalars, vectors, or matrices.
 

--- a/test/test-golden/example-simple.md
+++ b/test/test-golden/example-simple.md
@@ -13,7 +13,7 @@ Example description.
 |   |Type|Description|Required|
 |---|---|---|---|
 |**byteOffset**|`integer`|The offset relative to the start of the buffer in bytes.|No, default: `0`|
-|**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &#x2705; Yes|
+|**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &check; Yes|
 
 Additional properties are not allowed.
 
@@ -25,7 +25,7 @@ The offset relative to the start of the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: ` >= 0`
 
-### example.type &#x2705; 
+### example.type
 
 Specifies if the elements are scalars, vectors, or matrices.
 

--- a/test/test-golden/nested-embed.adoc
+++ b/test/test-golden/nested-embed.adoc
@@ -18,7 +18,7 @@ A view into a buffer.
 |**byteLength**
 |`integer`
 |The length of the bufferView in bytes.
-| &#x2705; Yes
+| &check; Yes
 
 |**byteStride**
 |`integer`
@@ -59,7 +59,7 @@ The offset into the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: `&gt;= 0`
 
-=== bufferView.byteLength &#x2705; 
+=== bufferView.byteLength
 
 The length of the bufferView in bytes.
 
@@ -467,7 +467,7 @@ The root object for a nestedTest asset.
 |**bufferViews**
 |<<reference-bufferview,`bufferView`>> `[1-*]`
 |An array of bufferViews.
-| &#x2705; Yes
+| &check; Yes
 
 |**materials**
 |<<reference-material,`material`>> `[1-*]`
@@ -505,7 +505,7 @@ Additional properties are allowed.
 
 * **JSON schema**: <<schema-reference-nestedtest,`nestedTest.schema.json`>>
 
-=== nestedTest.bufferViews &#x2705; 
+=== nestedTest.bufferViews
 
 An array of bufferViews.  This is the detailed description of the property.
 

--- a/test/test-golden/nested-linked.adoc
+++ b/test/test-golden/nested-linked.adoc
@@ -26,7 +26,7 @@ A view into a buffer.
 |**byteLength**
 |`integer`
 |The length of the bufferView in bytes.
-| &#x2705; Yes
+| &check; Yes
 
 |**byteStride**
 |`integer`
@@ -67,7 +67,7 @@ The offset into the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: `&gt;= 0`
 
-==== bufferView.byteLength &#x2705; 
+==== bufferView.byteLength
 
 The length of the bufferView in bytes.
 
@@ -475,7 +475,7 @@ The root object for a nestedTest asset.
 |**bufferViews**
 |<<reference-bufferview,`bufferView`>> `[1-*]`
 |An array of bufferViews.
-| &#x2705; Yes
+| &check; Yes
 
 |**materials**
 |<<reference-material,`material`>> `[1-*]`
@@ -513,7 +513,7 @@ Additional properties are allowed.
 
 * **JSON schema**: link:schema/nestedTest.schema.json[nestedTest.schema.json]
 
-==== nestedTest.bufferViews &#x2705; 
+==== nestedTest.bufferViews
 
 An array of bufferViews.  This is the detailed description of the property.
 

--- a/test/test-golden/nested-linked.md
+++ b/test/test-golden/nested-linked.md
@@ -19,7 +19,7 @@ A view into a buffer.
 |   |Type|Description|Required|
 |---|---|---|---|
 |**byteOffset**|`integer`|The offset into the buffer in bytes.|No, default: `0`|
-|**byteLength**|`integer`|The length of the bufferView in bytes.| &#x2705; Yes|
+|**byteLength**|`integer`|The length of the bufferView in bytes.| &check; Yes|
 |**byteStride**|`integer`|The stride, in bytes.|No|
 |**target**|`integer`|This is a test of some enums.|No|
 |**name**|`string`|The user-defined name of this object.|No|
@@ -38,7 +38,7 @@ The offset into the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: ` >= 0`
 
-#### bufferView.byteLength &#x2705; 
+#### bufferView.byteLength
 
 The length of the bufferView in bytes.
 
@@ -360,7 +360,7 @@ The root object for a nestedTest asset.
 
 |   |Type|Description|Required|
 |---|---|---|---|
-|**bufferViews**|[`bufferView`](#reference-bufferview) `[1-*]`|An array of bufferViews.| &#x2705; Yes|
+|**bufferViews**|[`bufferView`](#reference-bufferview) `[1-*]`|An array of bufferViews.| &check; Yes|
 |**materials**|[`material`](#reference-material) `[1-*]`|An array of materials.|No|
 |**images**|[`image`](#reference-image) `[1-*]`|An array of images.|No|
 |**version**|`string`|A version string with a specific pattern.|No|
@@ -372,7 +372,7 @@ Additional properties are allowed.
 
 * **JSON schema**: [nestedTest.schema.json](schema/nestedTest.schema.json)
 
-#### nestedTest.bufferViews &#x2705; 
+#### nestedTest.bufferViews
 
 An array of bufferViews.  This is the detailed description of the property.
 

--- a/test/test-golden/nested-remote.adoc
+++ b/test/test-golden/nested-remote.adoc
@@ -18,7 +18,7 @@ A view into a buffer.
 |**byteLength**
 |`integer`
 |The length of the bufferView in bytes.
-| &#x2705; Yes
+| &check; Yes
 
 |**byteStride**
 |`integer`
@@ -59,7 +59,7 @@ The offset into the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: `&gt;= 0`
 
-=== bufferView.byteLength &#x2705; 
+=== bufferView.byteLength
 
 The length of the bufferView in bytes.
 
@@ -467,7 +467,7 @@ The root object for a nestedTest asset.
 |**bufferViews**
 |<<reference-bufferview,`bufferView`>> `[1-*]`
 |An array of bufferViews.
-| &#x2705; Yes
+| &check; Yes
 
 |**materials**
 |<<reference-material,`material`>> `[1-*]`
@@ -505,7 +505,7 @@ Additional properties are allowed.
 
 * **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/nestedTest.schema.json[nestedTest.schema.json]
 
-=== nestedTest.bufferViews &#x2705; 
+=== nestedTest.bufferViews
 
 An array of bufferViews.  This is the detailed description of the property.
 

--- a/test/test-golden/nested-remote.md
+++ b/test/test-golden/nested-remote.md
@@ -11,7 +11,7 @@ A view into a buffer.
 |   |Type|Description|Required|
 |---|---|---|---|
 |**byteOffset**|`integer`|The offset into the buffer in bytes.|No, default: `0`|
-|**byteLength**|`integer`|The length of the bufferView in bytes.| &#x2705; Yes|
+|**byteLength**|`integer`|The length of the bufferView in bytes.| &check; Yes|
 |**byteStride**|`integer`|The stride, in bytes.|No|
 |**target**|`integer`|This is a test of some enums.|No|
 |**name**|`string`|The user-defined name of this object.|No|
@@ -30,7 +30,7 @@ The offset into the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: ` >= 0`
 
-### bufferView.byteLength &#x2705; 
+### bufferView.byteLength
 
 The length of the bufferView in bytes.
 
@@ -352,7 +352,7 @@ The root object for a nestedTest asset.
 
 |   |Type|Description|Required|
 |---|---|---|---|
-|**bufferViews**|[`bufferView`](#reference-bufferview) `[1-*]`|An array of bufferViews.| &#x2705; Yes|
+|**bufferViews**|[`bufferView`](#reference-bufferview) `[1-*]`|An array of bufferViews.| &check; Yes|
 |**materials**|[`material`](#reference-material) `[1-*]`|An array of materials.|No|
 |**images**|[`image`](#reference-image) `[1-*]`|An array of images.|No|
 |**version**|`string`|A version string with a specific pattern.|No|
@@ -364,7 +364,7 @@ Additional properties are allowed.
 
 * **JSON schema**: [nestedTest.schema.json](https://www.khronos.org/wetzel/just/testing/schema/nestedTest.schema.json)
 
-### nestedTest.bufferViews &#x2705; 
+### nestedTest.bufferViews
 
 An array of bufferViews.  This is the detailed description of the property.
 

--- a/test/test-golden/nested-simple.adoc
+++ b/test/test-golden/nested-simple.adoc
@@ -26,7 +26,7 @@ A view into a buffer.
 |**byteLength**
 |`integer`
 |The length of the bufferView in bytes.
-| &#x2705; Yes
+| &check; Yes
 
 |**byteStride**
 |`integer`
@@ -65,7 +65,7 @@ The offset into the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: `&gt;= 0`
 
-=== bufferView.byteLength &#x2705; 
+=== bufferView.byteLength
 
 The length of the bufferView in bytes.
 
@@ -465,7 +465,7 @@ The root object for a nestedTest asset.
 |**bufferViews**
 |`bufferView` `[1-*]`
 |An array of bufferViews.
-| &#x2705; Yes
+| &check; Yes
 
 |**materials**
 |`material` `[1-*]`
@@ -501,7 +501,7 @@ The root object for a nestedTest asset.
 
 Additional properties are allowed.
 
-=== nestedTest.bufferViews &#x2705; 
+=== nestedTest.bufferViews
 
 An array of bufferViews.  This is the detailed description of the property.
 

--- a/test/test-golden/nested-simple.md
+++ b/test/test-golden/nested-simple.md
@@ -19,7 +19,7 @@ A view into a buffer.
 |   |Type|Description|Required|
 |---|---|---|---|
 |**byteOffset**|`integer`|The offset into the buffer in bytes.|No, default: `0`|
-|**byteLength**|`integer`|The length of the bufferView in bytes.| &#x2705; Yes|
+|**byteLength**|`integer`|The length of the bufferView in bytes.| &check; Yes|
 |**byteStride**|`integer`|The stride, in bytes.|No|
 |**target**|`integer`|This is a test of some enums.|No|
 |**name**|`string`|The user-defined name of this object.|No|
@@ -36,7 +36,7 @@ The offset into the buffer in bytes.
 * **Required**: No, default: `0`
 * **Minimum**: ` >= 0`
 
-### bufferView.byteLength &#x2705; 
+### bufferView.byteLength
 
 The length of the bufferView in bytes.
 
@@ -350,7 +350,7 @@ The root object for a nestedTest asset.
 
 |   |Type|Description|Required|
 |---|---|---|---|
-|**bufferViews**|`bufferView` `[1-*]`|An array of bufferViews.| &#x2705; Yes|
+|**bufferViews**|`bufferView` `[1-*]`|An array of bufferViews.| &check; Yes|
 |**materials**|`material` `[1-*]`|An array of materials.|No|
 |**images**|`image` `[1-*]`|An array of images.|No|
 |**version**|`string`|A version string with a specific pattern.|No|
@@ -360,7 +360,7 @@ The root object for a nestedTest asset.
 
 Additional properties are allowed.
 
-### nestedTest.bufferViews &#x2705; 
+### nestedTest.bufferViews
 
 An array of bufferViews.  This is the detailed description of the property.
 


### PR DESCRIPTION
This introduces a more subtle "required" checkmark, changing &#x2705; to &check;.

It also removes the checkmark from sub-section headings, as they look bizarre in the TOC.