### PR TITLE
Support draft schema 2020-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 0.2.2 - UNRELEASED
+
+* Added support for certain features of newer JSON schema drafts. [#59](https://github.com/CesiumGS/wetzel/pull/59)
+
 ### 0.2.0, 0.2.1 - 2021-08-16
 
 * Added a new option to configure a keyword for "must" in hard-coded descriptions. [#57](https://github.com/CesiumGS/wetzel/pull/57)

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -542,19 +542,30 @@ function getAnyOfEnumString(schema, type, depth) {
     var length = propertyAnyOf.length;
     for (var i = 0; i < length; ++i) {
         var element = propertyAnyOf[i];
+        var constValue = element['const'];
         var enumValue = element['enum'];
         var enumDescription = element['description'];
+        var enumString;
 
-        // The likely scenario when there's no enum value is that it's the object
-        // containing the _type_ of the enum.  Otherwise, it should be an array with
-        // a single value in it.
-        if (!defined(enumValue) || !Array.isArray(enumValue) || enumValue.length === 0) {
-            continue;
+        // Check if 'const' has been used in place of 'enum'.
+        if (defined(constValue)) {
+            enumString = style.enumElement(constValue, type);
+            if (defined(enumDescription)) {
+                enumString += " " + enumDescription;
+            }
         }
+        else {
+            // The likely scenario when there's no enum value is that it's the object
+            // containing the _type_ of the enum.  Otherwise, it should be an array with
+            // a single value in it.
+            if (!defined(enumValue) || !Array.isArray(enumValue) || enumValue.length === 0) {
+                continue;
+            }
 
-        var enumString = style.enumElement(enumValue[0], type);
-        if (defined(enumDescription)) {
-            enumString += " " + enumDescription;
+            enumString = style.enumElement(enumValue[0], type);
+            if (defined(enumDescription)) {
+                enumString += " " + enumDescription;
+            }
         }
 
         allowedValues += style.bulletItem(enumString, depth);

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -44,9 +44,9 @@ function generateMarkdown(options) {
         else {
             resolved = schema4.resolve(schema, options.fileName, options.searchPath, options.ignorableTypes, options.debug);
             if ((!options.suppressWarnings) &&
-                (schemaRef === 'http://json-schema.org/draft-04/schema' ||
-                schemaRef === 'http://json-schema.org/draft-07/schema' ||
-                schemaRef === 'https://json-schema.org/draft/2020-12/schema')) {
+                (schemaRef !== 'http://json-schema.org/draft-04/schema' &&
+                schemaRef !== 'http://json-schema.org/draft-07/schema' &&
+                schemaRef !== 'https://json-schema.org/draft/2020-12/schema')) {
                 md += '> WETZEL_WARNING: Unrecognized JSON Schema.\n\n';
             }
         }

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -41,13 +41,13 @@ function generateMarkdown(options) {
         if (schemaRef === 'http://json-schema.org/draft-03/schema') {
             resolved = schema3.resolve(schema, options.fileName, options.searchPath, options.ignorableTypes, options.debug);
         }
-        else if (schemaRef === 'http://json-schema.org/draft-04/schema') {
-            resolved = schema4.resolve(schema, options.fileName, options.searchPath, options.ignorableTypes, options.debug);
-        }
         else {
-            resolved = schema3.resolve(schema, options.fileName, options.searchPath, options.ignorableTypes, options.debug);
-            if (!options.suppressWarnings) {
-                md += '> WETZEL_WARNING: Only JSON Schema 3 or 4 is supported. Treating as Schema 3.\n\n';
+            resolved = schema4.resolve(schema, options.fileName, options.searchPath, options.ignorableTypes, options.debug);
+            if ((!options.suppressWarnings) &&
+                (schemaRef === 'http://json-schema.org/draft-04/schema' ||
+                schemaRef === 'http://json-schema.org/draft-07/schema' ||
+                schemaRef === 'https://json-schema.org/draft/2020-12/schema')) {
+                md += '> WETZEL_WARNING: Unrecognized JSON Schema.\n\n';
             }
         }
     }
@@ -292,6 +292,18 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
             // TODO: items is a full schema
             var items = property.items;
             if (defined(items)) {
+                // Downgrade newer schemas
+                if (defined(items.exclusiveMinimum) && typeof items.exclusiveMinimum === 'number')
+                {
+                    items.minimum = items.exclusiveMinimum;
+                    items.exclusiveMinimum = true;
+                }
+                if (defined(items.exclusiveMaximum) && typeof items.exclusiveMaximum === 'number')
+                {
+                    items.maximum = items.exclusiveMaximum;
+                    items.exclusiveMaximum = true;
+                }
+
                 var itemsExclusiveMinimum = (defined(items.exclusiveMinimum) && items.exclusiveMinimum);
                 var minString = itemsExclusiveMinimum ? 'greater than' : 'greater than or equal to';
 
@@ -324,16 +336,26 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
 
             md += style.bulletItem(style.propertyDetails('Required') + ': ' + summary.required, 0);
 
-            var minimum = property.minimum;
-            if (defined(minimum)) {
-                var exclusiveMinimum = (defined(property.exclusiveMinimum) && property.exclusiveMinimum);
-                md += style.bulletItem(style.propertyDetails('Minimum') + ': ' + style.minMax((exclusiveMinimum ? ' > ' : ' >= ') + minimum), 0);
+            if (defined(property.exclusiveMinimum) && typeof property.exclusiveMinimum === 'number')
+            {
+                md += style.bulletItem(style.propertyDetails('Minimum') + ': ' + style.minMax(' > ' + property.exclusiveMinimum), 0);
+            } else {
+                var minimum = property.minimum;
+                if (defined(minimum)) {
+                    var exclusiveMinimum = (defined(property.exclusiveMinimum) && property.exclusiveMinimum);
+                    md += style.bulletItem(style.propertyDetails('Minimum') + ': ' + style.minMax((exclusiveMinimum ? ' > ' : ' >= ') + minimum), 0);
+                }
             }
 
-            var maximum = property.maximum;
-            if (defined(maximum)) {
-                var exclusiveMaximum = (defined(property.exclusiveMaximum) && property.exclusiveMaximum);
-                md += style.bulletItem(style.propertyDetails('Maximum') + ': ' + style.minMax((exclusiveMaximum ? ' < ' : ' <= ') + maximum), 0);
+            if (defined(property.exclusiveMaximum) && typeof property.exclusiveMaximum === 'number')
+            {
+                md += style.bulletItem(style.propertyDetails('Maximum') + ': ' + style.minMax(' < ' + property.exclusiveMaximum), 0);
+            } else {
+                var maximum = property.maximum;
+                if (defined(maximum)) {
+                    var exclusiveMaximum = (defined(property.exclusiveMaximum) && property.exclusiveMaximum);
+                    md += style.bulletItem(style.propertyDetails('Maximum') + ': ' + style.minMax((exclusiveMaximum ? ' < ' : ' <= ') + maximum), 0);
+                }
             }
 
             var format = property.format;

--- a/test/test-golden/v2020-12-embed.adoc
+++ b/test/test-golden/v2020-12-embed.adoc
@@ -1,0 +1,74 @@
+
+
+'''
+[#reference-image]
+== Image
+
+Image data used to create a texture. Image **MAY** be referenced by an URI (or IRI) or a buffer view index.
+
+.`Image` Properties
+|===
+|   |Type|Description|Required
+
+|**uri**
+|`string`
+|The URI (or IRI) of the image.
+|No
+
+|**mimeType**
+|`string`
+|The image's media type. This field **MUST** be defined when `bufferView` is defined.
+|No
+
+|**bufferView**
+|`integer`
+|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.
+|No
+
+|**fraction**
+|`number`
+|A number that **MUST** be between zero and one.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: <<schema-reference-image,`image.schema.json`>>
+
+=== Image.uri
+
+The URI (or IRI) of the image.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: iri-reference
+
+=== Image.mimeType
+
+The image's media type. This field **MUST** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Allowed values**:
+** `"image/jpeg"`
+** `"image/png"`
+
+=== Image.bufferView
+
+The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: `&gt;= 0`
+
+=== Image.fraction
+
+A number that **MUST** be between zero and one.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: `&gt; 0`
+* **Maximum**: `&lt; 1`
+
+

--- a/test/test-golden/v2020-12-embed.adoc
+++ b/test/test-golden/v2020-12-embed.adoc
@@ -30,6 +30,11 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |A number that **MUST** be between zero and one.
 |No
 
+|**moreFractions**
+|`number` `[3]`
+|An array of three fractional numbers.
+|No, default: `[0.1,0.2,0.3]`
+
 |===
 
 Additional properties are allowed.
@@ -70,5 +75,13 @@ A number that **MUST** be between zero and one.
 * **Required**: No
 * **Minimum**: `&gt; 0`
 * **Maximum**: `&lt; 1`
+
+=== Image.moreFractions
+
+An array of three fractional numbers.
+
+* **Type**: `number` `[3]`
+** Each element in the array must be greater than `0` and less than `1`.
+* **Required**: No, default: `[0.1,0.2,0.3]`
 
 

--- a/test/test-golden/v2020-12-embedJSON.adoc
+++ b/test/test-golden/v2020-12-embedJSON.adoc
@@ -1,0 +1,11 @@
+
+
+[#schema-reference-image]
+== JSON Schema for Image
+
+[source,json]
+----
+include::schema/image.schema.json[]
+----
+
+<<<

--- a/test/test-golden/v2020-12-keyword.md
+++ b/test/test-golden/v2020-12-keyword.md
@@ -16,6 +16,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |**mimeType**|`string`|The image's media type. This field **MUST** be defined when `bufferView` is defined.|No|
 |**bufferView**|`integer`|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.|No|
 |**fraction**|`number`|A number that **MUST** be between zero and one.|No|
+|**moreFractions**|`number` `[3]`|An array of three fractional numbers.|No, default: `[0.1,0.2,0.3]`|
 
 Additional properties are allowed.
 
@@ -53,5 +54,13 @@ A number that **MUST** be between zero and one.
 * **Required**: No
 * **Minimum**: ` > 0`
 * **Maximum**: ` < 1`
+
+### Image.moreFractions
+
+An array of three fractional numbers.
+
+* **Type**: `number` `[3]`
+   * Each element in the array **MUST** be greater than `0` and less than `1`.
+* **Required**: No, default: `[0.1,0.2,0.3]`
 
 

--- a/test/test-golden/v2020-12-keyword.md
+++ b/test/test-golden/v2020-12-keyword.md
@@ -1,0 +1,57 @@
+# Objects
+* [`Image`](#reference-image) (root object)
+
+
+---------------------------------------
+<a name="reference-image"></a>
+## Image
+
+Image data used to create a texture. Image **MAY** be referenced by an URI (or IRI) or a buffer view index.
+
+**`Image` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**uri**|`string`|The URI (or IRI) of the image.|No|
+|**mimeType**|`string`|The image's media type. This field **MUST** be defined when `bufferView` is defined.|No|
+|**bufferView**|`integer`|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.|No|
+|**fraction**|`number`|A number that **MUST** be between zero and one.|No|
+
+Additional properties are allowed.
+
+### Image.uri
+
+The URI (or IRI) of the image.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: iri-reference
+
+### Image.mimeType
+
+The image's media type. This field **MUST** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Allowed values**:
+   * `"image/jpeg"`
+   * `"image/png"`
+
+### Image.bufferView
+
+The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+### Image.fraction
+
+A number that **MUST** be between zero and one.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+* **Maximum**: ` < 1`
+
+

--- a/test/test-golden/v2020-12-linked.adoc
+++ b/test/test-golden/v2020-12-linked.adoc
@@ -1,0 +1,76 @@
+== Objects
+* <<reference-image,`Image`>> (root object)
+
+
+'''
+[#reference-image]
+=== Image
+
+Image data used to create a texture. Image **MAY** be referenced by an URI (or IRI) or a buffer view index.
+
+.`Image` Properties
+|===
+|   |Type|Description|Required
+
+|**uri**
+|`string`
+|The URI (or IRI) of the image.
+|No
+
+|**mimeType**
+|`string`
+|The image's media type. This field **MUST** be defined when `bufferView` is defined.
+|No
+
+|**bufferView**
+|`integer`
+|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.
+|No
+
+|**fraction**
+|`number`
+|A number that **MUST** be between zero and one.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/image.schema.json[image.schema.json]
+
+==== Image.uri
+
+The URI (or IRI) of the image.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: iri-reference
+
+==== Image.mimeType
+
+The image's media type. This field **MUST** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Allowed values**:
+** `"image/jpeg"`
+** `"image/png"`
+
+==== Image.bufferView
+
+The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: `&gt;= 0`
+
+==== Image.fraction
+
+A number that **MUST** be between zero and one.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: `&gt; 0`
+* **Maximum**: `&lt; 1`
+
+

--- a/test/test-golden/v2020-12-linked.adoc
+++ b/test/test-golden/v2020-12-linked.adoc
@@ -32,6 +32,11 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |A number that **MUST** be between zero and one.
 |No
 
+|**moreFractions**
+|`number` `[3]`
+|An array of three fractional numbers.
+|No, default: `[0.1,0.2,0.3]`
+
 |===
 
 Additional properties are allowed.
@@ -72,5 +77,13 @@ A number that **MUST** be between zero and one.
 * **Required**: No
 * **Minimum**: `&gt; 0`
 * **Maximum**: `&lt; 1`
+
+==== Image.moreFractions
+
+An array of three fractional numbers.
+
+* **Type**: `number` `[3]`
+** Each element in the array must be greater than `0` and less than `1`.
+* **Required**: No, default: `[0.1,0.2,0.3]`
 
 

--- a/test/test-golden/v2020-12-linked.md
+++ b/test/test-golden/v2020-12-linked.md
@@ -1,0 +1,59 @@
+## Objects
+* [`Image`](#reference-image) (root object)
+
+
+---------------------------------------
+<a name="reference-image"></a>
+### Image
+
+Image data used to create a texture. Image **MAY** be referenced by an URI (or IRI) or a buffer view index.
+
+**`Image` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**uri**|`string`|The URI (or IRI) of the image.|No|
+|**mimeType**|`string`|The image's media type. This field **MUST** be defined when `bufferView` is defined.|No|
+|**bufferView**|`integer`|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.|No|
+|**fraction**|`number`|A number that **MUST** be between zero and one.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [image.schema.json](schema/image.schema.json)
+
+#### Image.uri
+
+The URI (or IRI) of the image.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: iri-reference
+
+#### Image.mimeType
+
+The image's media type. This field **MUST** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Allowed values**:
+   * `"image/jpeg"`
+   * `"image/png"`
+
+#### Image.bufferView
+
+The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+#### Image.fraction
+
+A number that **MUST** be between zero and one.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+* **Maximum**: ` < 1`
+
+

--- a/test/test-golden/v2020-12-linked.md
+++ b/test/test-golden/v2020-12-linked.md
@@ -16,6 +16,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |**mimeType**|`string`|The image's media type. This field **MUST** be defined when `bufferView` is defined.|No|
 |**bufferView**|`integer`|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.|No|
 |**fraction**|`number`|A number that **MUST** be between zero and one.|No|
+|**moreFractions**|`number` `[3]`|An array of three fractional numbers.|No, default: `[0.1,0.2,0.3]`|
 
 Additional properties are allowed.
 
@@ -55,5 +56,13 @@ A number that **MUST** be between zero and one.
 * **Required**: No
 * **Minimum**: ` > 0`
 * **Maximum**: ` < 1`
+
+#### Image.moreFractions
+
+An array of three fractional numbers.
+
+* **Type**: `number` `[3]`
+   * Each element in the array must be greater than `0` and less than `1`.
+* **Required**: No, default: `[0.1,0.2,0.3]`
 
 

--- a/test/test-golden/v2020-12-remote.adoc
+++ b/test/test-golden/v2020-12-remote.adoc
@@ -1,0 +1,74 @@
+
+
+'''
+[#reference-image]
+== Image
+
+Image data used to create a texture. Image **MAY** be referenced by an URI (or IRI) or a buffer view index.
+
+.`Image` Properties
+|===
+|   |Type|Description|Required
+
+|**uri**
+|`string`
+|The URI (or IRI) of the image.
+|No
+
+|**mimeType**
+|`string`
+|The image's media type. This field **MUST** be defined when `bufferView` is defined.
+|No
+
+|**bufferView**
+|`integer`
+|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.
+|No
+
+|**fraction**
+|`number`
+|A number that **MUST** be between zero and one.
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/image.schema.json[image.schema.json]
+
+=== Image.uri
+
+The URI (or IRI) of the image.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: iri-reference
+
+=== Image.mimeType
+
+The image's media type. This field **MUST** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Allowed values**:
+** `"image/jpeg"`
+** `"image/png"`
+
+=== Image.bufferView
+
+The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: `&gt;= 0`
+
+=== Image.fraction
+
+A number that **MUST** be between zero and one.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: `&gt; 0`
+* **Maximum**: `&lt; 1`
+
+

--- a/test/test-golden/v2020-12-remote.adoc
+++ b/test/test-golden/v2020-12-remote.adoc
@@ -30,6 +30,11 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |A number that **MUST** be between zero and one.
 |No
 
+|**moreFractions**
+|`number` `[3]`
+|An array of three fractional numbers.
+|No, default: `[0.1,0.2,0.3]`
+
 |===
 
 Additional properties are allowed.
@@ -70,5 +75,13 @@ A number that **MUST** be between zero and one.
 * **Required**: No
 * **Minimum**: `&gt; 0`
 * **Maximum**: `&lt; 1`
+
+=== Image.moreFractions
+
+An array of three fractional numbers.
+
+* **Type**: `number` `[3]`
+** Each element in the array must be greater than `0` and less than `1`.
+* **Required**: No, default: `[0.1,0.2,0.3]`
 
 

--- a/test/test-golden/v2020-12-remote.md
+++ b/test/test-golden/v2020-12-remote.md
@@ -1,0 +1,57 @@
+
+
+---------------------------------------
+<a name="reference-image"></a>
+## Image
+
+Image data used to create a texture. Image **MAY** be referenced by an URI (or IRI) or a buffer view index.
+
+**`Image` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**uri**|`string`|The URI (or IRI) of the image.|No|
+|**mimeType**|`string`|The image's media type. This field **MUST** be defined when `bufferView` is defined.|No|
+|**bufferView**|`integer`|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.|No|
+|**fraction**|`number`|A number that **MUST** be between zero and one.|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [image.schema.json](https://www.khronos.org/wetzel/just/testing/schema/image.schema.json)
+
+### Image.uri
+
+The URI (or IRI) of the image.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: iri-reference
+
+### Image.mimeType
+
+The image's media type. This field **MUST** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Allowed values**:
+   * `"image/jpeg"`
+   * `"image/png"`
+
+### Image.bufferView
+
+The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+### Image.fraction
+
+A number that **MUST** be between zero and one.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+* **Maximum**: ` < 1`
+
+

--- a/test/test-golden/v2020-12-remote.md
+++ b/test/test-golden/v2020-12-remote.md
@@ -14,6 +14,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |**mimeType**|`string`|The image's media type. This field **MUST** be defined when `bufferView` is defined.|No|
 |**bufferView**|`integer`|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.|No|
 |**fraction**|`number`|A number that **MUST** be between zero and one.|No|
+|**moreFractions**|`number` `[3]`|An array of three fractional numbers.|No, default: `[0.1,0.2,0.3]`|
 
 Additional properties are allowed.
 
@@ -53,5 +54,13 @@ A number that **MUST** be between zero and one.
 * **Required**: No
 * **Minimum**: ` > 0`
 * **Maximum**: ` < 1`
+
+### Image.moreFractions
+
+An array of three fractional numbers.
+
+* **Type**: `number` `[3]`
+   * Each element in the array must be greater than `0` and less than `1`.
+* **Required**: No, default: `[0.1,0.2,0.3]`
 
 

--- a/test/test-golden/v2020-12-simple.adoc
+++ b/test/test-golden/v2020-12-simple.adoc
@@ -32,6 +32,11 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |A number that **MUST** be between zero and one.
 |No
 
+|**moreFractions**
+|`number` `[3]`
+|An array of three fractional numbers.
+|No, default: `[0.1,0.2,0.3]`
+
 |===
 
 Additional properties are allowed.
@@ -70,5 +75,13 @@ A number that **MUST** be between zero and one.
 * **Required**: No
 * **Minimum**: `&gt; 0`
 * **Maximum**: `&lt; 1`
+
+=== Image.moreFractions
+
+An array of three fractional numbers.
+
+* **Type**: `number` `[3]`
+** Each element in the array must be greater than `0` and less than `1`.
+* **Required**: No, default: `[0.1,0.2,0.3]`
 
 

--- a/test/test-golden/v2020-12-simple.adoc
+++ b/test/test-golden/v2020-12-simple.adoc
@@ -1,0 +1,74 @@
+= Objects
+* <<reference-image,`Image`>> (root object)
+
+
+'''
+[#reference-image]
+== Image
+
+Image data used to create a texture. Image **MAY** be referenced by an URI (or IRI) or a buffer view index.
+
+.`Image` Properties
+|===
+|   |Type|Description|Required
+
+|**uri**
+|`string`
+|The URI (or IRI) of the image.
+|No
+
+|**mimeType**
+|`string`
+|The image's media type. This field **MUST** be defined when `bufferView` is defined.
+|No
+
+|**bufferView**
+|`integer`
+|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.
+|No
+
+|**fraction**
+|`number`
+|A number that **MUST** be between zero and one.
+|No
+
+|===
+
+Additional properties are allowed.
+
+=== Image.uri
+
+The URI (or IRI) of the image.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: iri-reference
+
+=== Image.mimeType
+
+The image's media type. This field **MUST** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Allowed values**:
+** `"image/jpeg"`
+** `"image/png"`
+
+=== Image.bufferView
+
+The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: `&gt;= 0`
+
+=== Image.fraction
+
+A number that **MUST** be between zero and one.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: `&gt; 0`
+* **Maximum**: `&lt; 1`
+
+

--- a/test/test-golden/v2020-12-simple.md
+++ b/test/test-golden/v2020-12-simple.md
@@ -16,6 +16,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |**mimeType**|`string`|The image's media type. This field **MUST** be defined when `bufferView` is defined.|No|
 |**bufferView**|`integer`|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.|No|
 |**fraction**|`number`|A number that **MUST** be between zero and one.|No|
+|**moreFractions**|`number` `[3]`|An array of three fractional numbers.|No, default: `[0.1,0.2,0.3]`|
 
 Additional properties are allowed.
 
@@ -53,5 +54,13 @@ A number that **MUST** be between zero and one.
 * **Required**: No
 * **Minimum**: ` > 0`
 * **Maximum**: ` < 1`
+
+### Image.moreFractions
+
+An array of three fractional numbers.
+
+* **Type**: `number` `[3]`
+   * Each element in the array must be greater than `0` and less than `1`.
+* **Required**: No, default: `[0.1,0.2,0.3]`
 
 

--- a/test/test-golden/v2020-12-simple.md
+++ b/test/test-golden/v2020-12-simple.md
@@ -1,0 +1,57 @@
+# Objects
+* [`Image`](#reference-image) (root object)
+
+
+---------------------------------------
+<a name="reference-image"></a>
+## Image
+
+Image data used to create a texture. Image **MAY** be referenced by an URI (or IRI) or a buffer view index.
+
+**`Image` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**uri**|`string`|The URI (or IRI) of the image.|No|
+|**mimeType**|`string`|The image's media type. This field **MUST** be defined when `bufferView` is defined.|No|
+|**bufferView**|`integer`|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.|No|
+|**fraction**|`number`|A number that **MUST** be between zero and one.|No|
+
+Additional properties are allowed.
+
+### Image.uri
+
+The URI (or IRI) of the image.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Format**: iri-reference
+
+### Image.mimeType
+
+The image's media type. This field **MUST** be defined when `bufferView` is defined.
+
+* **Type**: `string`
+* **Required**: No
+* **Allowed values**:
+   * `"image/jpeg"`
+   * `"image/png"`
+
+### Image.bufferView
+
+The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.
+
+* **Type**: `integer`
+* **Required**: No
+* **Minimum**: ` >= 0`
+
+### Image.fraction
+
+A number that **MUST** be between zero and one.
+
+* **Type**: `number`
+* **Required**: No
+* **Minimum**: ` > 0`
+* **Maximum**: ` < 1`
+
+

--- a/test/test-schemas/index.json
+++ b/test/test-schemas/index.json
@@ -16,5 +16,8 @@
         "name": "nested",
         "path": "nested/nestedTest.schema.json",
         "ignore": "['nestedid.schema.json', 'nestedchildofrootproperty.schema.json', 'nestedtestproperty.schema.json']"
+    }, {
+        "name": "v2020-12",
+        "path": "v2020-12/image.schema.json"
     }]
 }

--- a/test/test-schemas/v2020-12/image.schema.json
+++ b/test/test-schemas/v2020-12/image.schema.json
@@ -36,6 +36,18 @@
             "description": "A number that **MUST** be between zero and one.",
             "exclusiveMinimum": 0.0,
             "exclusiveMaximum": 1.0
+        },
+        "moreFractions" : {
+            "type" : "array",
+            "description" : "An array of three fractional numbers.",
+            "items" : {
+                "type": "number",
+                "exclusiveMinimum" : 0.0,
+                "exclusiveMaximum" : 1.0
+            },
+            "minItems" : 3,
+            "maxItems" : 3,
+            "default" : [0.1, 0.2, 0.3]
         }
     },
     "dependencies": {

--- a/test/test-schemas/v2020-12/image.schema.json
+++ b/test/test-schemas/v2020-12/image.schema.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "image.schema.json",
+    "title": "Image",
+    "type": "object",
+    "description": "Image data used to create a texture. Image **MAY** be referenced by an URI (or IRI) or a buffer view index.",
+    "properties": {
+        "uri": {
+            "type": "string",
+            "description": "The URI (or IRI) of the image.",
+            "format": "iri-reference",
+            "gltf_detailedDescription": "The URI (or IRI) of the image.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.",
+            "gltf_uriType": "image"
+        },
+        "mimeType": {
+            "anyOf": [
+                {
+                    "const": "image/jpeg"
+                },
+                {
+                    "const": "image/png"
+                },
+                {
+                    "type": "string"
+                }
+            ],
+            "description": "The image's media type. This field **MUST** be defined when `bufferView` is defined."
+        },
+        "bufferView": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined."
+        },
+        "fraction": {
+            "type": "number",
+            "description": "A number that **MUST** be between zero and one.",
+            "exclusiveMinimum": 0.0,
+            "exclusiveMaximum": 1.0
+        }
+    },
+    "dependencies": {
+        "bufferView": [ "mimeType" ]
+    },
+    "oneOf": [
+        { "required": [ "uri" ] },
+        { "required": [ "bufferView" ] }
+    ]
+}


### PR DESCRIPTION
Added support for features from 2020-12 that are needed by the latest glTF spec.

Supersedes #41.