### PR TITLE
Indent nested bullets four spaces

### DIFF
--- a/lib/style.js
+++ b/lib/style.js
@@ -252,7 +252,7 @@ function bulletItem(item, indentationLevel) {
     if (isADoc()) {
         return ('*'.repeat(indentationLevel + 1)) + ' ' + item + '\n';
     }
-    return (' '.repeat(indentationLevel * 3)) + '* ' + item + '\n';
+    return (' '.repeat(indentationLevel * 4)) + '* ' + item + '\n';
 }
 
 /**

--- a/test/test-golden/example-keyword.md
+++ b/test/test-golden/example-keyword.md
@@ -32,12 +32,12 @@ Specifies if the elements are scalars, vectors, or matrices.
 * **Type**: `string`
 * **Required**:  &#10003; Yes
 * **Allowed values**:
-   * `"SCALAR"`
-   * `"VEC2"`
-   * `"VEC3"`
-   * `"VEC4"`
-   * `"MAT2"`
-   * `"MAT3"`
-   * `"MAT4"`
+    * `"SCALAR"`
+    * `"VEC2"`
+    * `"VEC3"`
+    * `"VEC4"`
+    * `"MAT2"`
+    * `"MAT3"`
+    * `"MAT4"`
 
 

--- a/test/test-golden/example-linked.md
+++ b/test/test-golden/example-linked.md
@@ -34,12 +34,12 @@ Specifies if the elements are scalars, vectors, or matrices.
 * **Type**: `string`
 * **Required**:  &#10003; Yes
 * **Allowed values**:
-   * `"SCALAR"`
-   * `"VEC2"`
-   * `"VEC3"`
-   * `"VEC4"`
-   * `"MAT2"`
-   * `"MAT3"`
-   * `"MAT4"`
+    * `"SCALAR"`
+    * `"VEC2"`
+    * `"VEC3"`
+    * `"VEC4"`
+    * `"MAT2"`
+    * `"MAT3"`
+    * `"MAT4"`
 
 

--- a/test/test-golden/example-remote.md
+++ b/test/test-golden/example-remote.md
@@ -32,12 +32,12 @@ Specifies if the elements are scalars, vectors, or matrices.
 * **Type**: `string`
 * **Required**:  &#10003; Yes
 * **Allowed values**:
-   * `"SCALAR"`
-   * `"VEC2"`
-   * `"VEC3"`
-   * `"VEC4"`
-   * `"MAT2"`
-   * `"MAT3"`
-   * `"MAT4"`
+    * `"SCALAR"`
+    * `"VEC2"`
+    * `"VEC3"`
+    * `"VEC4"`
+    * `"MAT2"`
+    * `"MAT3"`
+    * `"MAT4"`
 
 

--- a/test/test-golden/example-simple.md
+++ b/test/test-golden/example-simple.md
@@ -32,12 +32,12 @@ Specifies if the elements are scalars, vectors, or matrices.
 * **Type**: `string`
 * **Required**:  &#10003; Yes
 * **Allowed values**:
-   * `"SCALAR"`
-   * `"VEC2"`
-   * `"VEC3"`
-   * `"VEC4"`
-   * `"MAT2"`
-   * `"MAT3"`
-   * `"MAT4"`
+    * `"SCALAR"`
+    * `"VEC2"`
+    * `"VEC3"`
+    * `"VEC4"`
+    * `"MAT2"`
+    * `"MAT3"`
+    * `"MAT4"`
 
 

--- a/test/test-golden/nested-keyword.md
+++ b/test/test-golden/nested-keyword.md
@@ -4,7 +4,7 @@
 * [`Extras`](#reference-extras)
 * [`Image`](#reference-image)
 * [`Material`](#reference-material)
-   * [`PBR Metallic Roughness`](#reference-material-pbrmetallicroughness)
+    * [`PBR Metallic Roughness`](#reference-material-pbrmetallicroughness)
 * [`nestedTest`](#reference-nestedtest) (root object)
 
 
@@ -61,8 +61,8 @@ This is a test of some enums.
 * **Type**: `integer`
 * **Required**: No
 * **Allowed values**:
-   * `34962` ARRAY_BUFFER
-   * `34963` ELEMENT_ARRAY_BUFFER
+    * `34962` ARRAY_BUFFER
+    * `34963` ELEMENT_ARRAY_BUFFER
 * **Related WebGL functions**: `bindBuffer()`
 
 ### bufferView.name
@@ -146,8 +146,8 @@ The image's MIME type. Required if `bufferView` is defined.
 * **Type**: `string`
 * **Required**: No
 * **Allowed values**:
-   * `"image/jpeg"`
-   * `"image/png"`
+    * `"image/jpeg"`
+    * `"image/png"`
 
 ### image.bufferView
 
@@ -246,7 +246,7 @@ A set of parameter values that are used to define the metallic-roughness materia
 The RGB components of the emissive color of the material. This is the detailed description of the property.
 
 * **Type**: `number` `[3]`
-   * Each element in the array **MUST** be greater than or equal to `0` and less than or equal to `1`.
+    * Each element in the array **MUST** be greater than or equal to `0` and less than or equal to `1`.
 * **Required**: No, default: `[0,0,0]`
 
 ### material.alphaMode
@@ -256,9 +256,9 @@ The material's alpha rendering mode enumeration specifying the interpretation of
 * **Type**: `string`
 * **Required**: No, default: `"OPAQUE"`
 * **Allowed values**:
-   * `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
-   * `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
-   * `"BLEND"` The alpha value is used to composite the source and destination areas.
+    * `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
+    * `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
+    * `"BLEND"` The alpha value is used to composite the source and destination areas.
 
 ### material.alphaCutoff
 
@@ -301,7 +301,7 @@ Additional properties are allowed.
 The RGBA components of the base color of the material. This is the detailed description of the property.
 
 * **Type**: `number` `[4]`
-   * Each element in the array **MUST** be greater than or equal to `0` and less than or equal to `1`.
+    * Each element in the array **MUST** be greater than or equal to `0` and less than or equal to `1`.
 * **Required**: No, default: `[1,1,1,1]`
 
 ### material.pbrMetallicRoughness.metallicFactor

--- a/test/test-golden/nested-linked.md
+++ b/test/test-golden/nested-linked.md
@@ -4,7 +4,7 @@
 * [`Extras`](#reference-extras)
 * [`Image`](#reference-image)
 * [`Material`](#reference-material)
-   * [`PBR Metallic Roughness`](#reference-material-pbrmetallicroughness)
+    * [`PBR Metallic Roughness`](#reference-material-pbrmetallicroughness)
 * [`nestedTest`](#reference-nestedtest) (root object)
 
 
@@ -63,8 +63,8 @@ This is a test of some enums.
 * **Type**: `integer`
 * **Required**: No
 * **Allowed values**:
-   * `34962` ARRAY_BUFFER
-   * `34963` ELEMENT_ARRAY_BUFFER
+    * `34962` ARRAY_BUFFER
+    * `34963` ELEMENT_ARRAY_BUFFER
 * **Related WebGL functions**: `bindBuffer()`
 
 #### bufferView.name
@@ -152,8 +152,8 @@ The image's MIME type. Required if `bufferView` is defined.
 * **Type**: `string`
 * **Required**: No
 * **Allowed values**:
-   * `"image/jpeg"`
-   * `"image/png"`
+    * `"image/jpeg"`
+    * `"image/png"`
 
 #### image.bufferView
 
@@ -254,7 +254,7 @@ A set of parameter values that are used to define the metallic-roughness materia
 The RGB components of the emissive color of the material. This is the detailed description of the property.
 
 * **Type**: `number` `[3]`
-   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+    * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
 * **Required**: No, default: `[0,0,0]`
 
 #### material.alphaMode
@@ -264,9 +264,9 @@ The material's alpha rendering mode enumeration specifying the interpretation of
 * **Type**: `string`
 * **Required**: No, default: `"OPAQUE"`
 * **Allowed values**:
-   * `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
-   * `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
-   * `"BLEND"` The alpha value is used to composite the source and destination areas.
+    * `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
+    * `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
+    * `"BLEND"` The alpha value is used to composite the source and destination areas.
 
 #### material.alphaCutoff
 
@@ -311,7 +311,7 @@ Additional properties are allowed.
 The RGBA components of the base color of the material. This is the detailed description of the property.
 
 * **Type**: `number` `[4]`
-   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+    * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
 * **Required**: No, default: `[1,1,1,1]`
 
 #### material.pbrMetallicRoughness.metallicFactor

--- a/test/test-golden/nested-remote.md
+++ b/test/test-golden/nested-remote.md
@@ -55,8 +55,8 @@ This is a test of some enums.
 * **Type**: `integer`
 * **Required**: No
 * **Allowed values**:
-   * `34962` ARRAY_BUFFER
-   * `34963` ELEMENT_ARRAY_BUFFER
+    * `34962` ARRAY_BUFFER
+    * `34963` ELEMENT_ARRAY_BUFFER
 * **Related WebGL functions**: `bindBuffer()`
 
 ### bufferView.name
@@ -144,8 +144,8 @@ The image's MIME type. Required if `bufferView` is defined.
 * **Type**: `string`
 * **Required**: No
 * **Allowed values**:
-   * `"image/jpeg"`
-   * `"image/png"`
+    * `"image/jpeg"`
+    * `"image/png"`
 
 ### image.bufferView
 
@@ -246,7 +246,7 @@ A set of parameter values that are used to define the metallic-roughness materia
 The RGB components of the emissive color of the material. This is the detailed description of the property.
 
 * **Type**: `number` `[3]`
-   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+    * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
 * **Required**: No, default: `[0,0,0]`
 
 ### material.alphaMode
@@ -256,9 +256,9 @@ The material's alpha rendering mode enumeration specifying the interpretation of
 * **Type**: `string`
 * **Required**: No, default: `"OPAQUE"`
 * **Allowed values**:
-   * `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
-   * `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
-   * `"BLEND"` The alpha value is used to composite the source and destination areas.
+    * `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
+    * `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
+    * `"BLEND"` The alpha value is used to composite the source and destination areas.
 
 ### material.alphaCutoff
 
@@ -303,7 +303,7 @@ Additional properties are allowed.
 The RGBA components of the base color of the material. This is the detailed description of the property.
 
 * **Type**: `number` `[4]`
-   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+    * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
 * **Required**: No, default: `[1,1,1,1]`
 
 ### material.pbrMetallicRoughness.metallicFactor

--- a/test/test-golden/nested-simple.md
+++ b/test/test-golden/nested-simple.md
@@ -4,7 +4,7 @@
 * [`Extras`](#reference-extras)
 * [`Image`](#reference-image)
 * [`Material`](#reference-material)
-   * [`PBR Metallic Roughness`](#reference-material-pbrmetallicroughness)
+    * [`PBR Metallic Roughness`](#reference-material-pbrmetallicroughness)
 * [`nestedTest`](#reference-nestedtest) (root object)
 
 
@@ -61,8 +61,8 @@ This is a test of some enums.
 * **Type**: `integer`
 * **Required**: No
 * **Allowed values**:
-   * `34962` ARRAY_BUFFER
-   * `34963` ELEMENT_ARRAY_BUFFER
+    * `34962` ARRAY_BUFFER
+    * `34963` ELEMENT_ARRAY_BUFFER
 * **Related WebGL functions**: `bindBuffer()`
 
 ### bufferView.name
@@ -146,8 +146,8 @@ The image's MIME type. Required if `bufferView` is defined.
 * **Type**: `string`
 * **Required**: No
 * **Allowed values**:
-   * `"image/jpeg"`
-   * `"image/png"`
+    * `"image/jpeg"`
+    * `"image/png"`
 
 ### image.bufferView
 
@@ -246,7 +246,7 @@ A set of parameter values that are used to define the metallic-roughness materia
 The RGB components of the emissive color of the material. This is the detailed description of the property.
 
 * **Type**: `number` `[3]`
-   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+    * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
 * **Required**: No, default: `[0,0,0]`
 
 ### material.alphaMode
@@ -256,9 +256,9 @@ The material's alpha rendering mode enumeration specifying the interpretation of
 * **Type**: `string`
 * **Required**: No, default: `"OPAQUE"`
 * **Allowed values**:
-   * `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
-   * `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
-   * `"BLEND"` The alpha value is used to composite the source and destination areas.
+    * `"OPAQUE"` The alpha value is ignored and the rendered output is fully opaque.
+    * `"MASK"` The rendered output is either fully opaque or fully transparent depending on the alpha value and the specified alpha cutoff value.
+    * `"BLEND"` The alpha value is used to composite the source and destination areas.
 
 ### material.alphaCutoff
 
@@ -301,7 +301,7 @@ Additional properties are allowed.
 The RGBA components of the base color of the material. This is the detailed description of the property.
 
 * **Type**: `number` `[4]`
-   * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
+    * Each element in the array must be greater than or equal to `0` and less than or equal to `1`.
 * **Required**: No, default: `[1,1,1,1]`
 
 ### material.pbrMetallicRoughness.metallicFactor

--- a/test/test-golden/v2020-12-keyword.md
+++ b/test/test-golden/v2020-12-keyword.md
@@ -35,8 +35,8 @@ The image's media type. This field **MUST** be defined when `bufferView` is defi
 * **Type**: `string`
 * **Required**: No
 * **Allowed values**:
-   * `"image/jpeg"`
-   * `"image/png"`
+    * `"image/jpeg"`
+    * `"image/png"`
 
 ### Image.bufferView
 
@@ -60,7 +60,7 @@ A number that **MUST** be between zero and one.
 An array of three fractional numbers.
 
 * **Type**: `number` `[3]`
-   * Each element in the array **MUST** be greater than `0` and less than `1`.
+    * Each element in the array **MUST** be greater than `0` and less than `1`.
 * **Required**: No, default: `[0.1,0.2,0.3]`
 
 

--- a/test/test-golden/v2020-12-linked.md
+++ b/test/test-golden/v2020-12-linked.md
@@ -37,8 +37,8 @@ The image's media type. This field **MUST** be defined when `bufferView` is defi
 * **Type**: `string`
 * **Required**: No
 * **Allowed values**:
-   * `"image/jpeg"`
-   * `"image/png"`
+    * `"image/jpeg"`
+    * `"image/png"`
 
 #### Image.bufferView
 
@@ -62,7 +62,7 @@ A number that **MUST** be between zero and one.
 An array of three fractional numbers.
 
 * **Type**: `number` `[3]`
-   * Each element in the array must be greater than `0` and less than `1`.
+    * Each element in the array must be greater than `0` and less than `1`.
 * **Required**: No, default: `[0.1,0.2,0.3]`
 
 

--- a/test/test-golden/v2020-12-remote.md
+++ b/test/test-golden/v2020-12-remote.md
@@ -35,8 +35,8 @@ The image's media type. This field **MUST** be defined when `bufferView` is defi
 * **Type**: `string`
 * **Required**: No
 * **Allowed values**:
-   * `"image/jpeg"`
-   * `"image/png"`
+    * `"image/jpeg"`
+    * `"image/png"`
 
 ### Image.bufferView
 
@@ -60,7 +60,7 @@ A number that **MUST** be between zero and one.
 An array of three fractional numbers.
 
 * **Type**: `number` `[3]`
-   * Each element in the array must be greater than `0` and less than `1`.
+    * Each element in the array must be greater than `0` and less than `1`.
 * **Required**: No, default: `[0.1,0.2,0.3]`
 
 

--- a/test/test-golden/v2020-12-simple.md
+++ b/test/test-golden/v2020-12-simple.md
@@ -35,8 +35,8 @@ The image's media type. This field **MUST** be defined when `bufferView` is defi
 * **Type**: `string`
 * **Required**: No
 * **Allowed values**:
-   * `"image/jpeg"`
-   * `"image/png"`
+    * `"image/jpeg"`
+    * `"image/png"`
 
 ### Image.bufferView
 
@@ -60,7 +60,7 @@ A number that **MUST** be between zero and one.
 An array of three fractional numbers.
 
 * **Type**: `number` `[3]`
-   * Each element in the array must be greater than `0` and less than `1`.
+    * Each element in the array must be greater than `0` and less than `1`.
 * **Required**: No, default: `[0.1,0.2,0.3]`
 
 


### PR DESCRIPTION
Instead of three. This brings the output into compliance with the [Markdown spec](https://daringfireball.net/projects/markdown/syntax#list), and allows for the generation of properly nested lists by
[commonmarker](https://github.com/gjtorikian/commonmarker) and [Multimarkdown](https://fletcherpenney.net/multimarkdown/).