### PR TITLE
fix for minimist, jsonpointer, and ansi-regex security advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wetzel",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "description": "Generate Markdown or AsciiDoctor documentation from JSON Schema",
     "license": "Apache-2.0",
     "author": {
@@ -26,8 +26,8 @@
         "lib": "./lib"
     },
     "dependencies": {
-        "jsonpointer": "^4.1.0",
-        "minimist": "1.1.0"
+        "jsonpointer": "^5.0.0",
+        "minimist": "^1.2.2"
     },
     "devDependencies": {
         "eslint": "^7.10.0",


### PR DESCRIPTION
fix for minimist, jsonpointer, and ansi-regex security advisories
- https://github.com/advisories/GHSA-vh95-rmgr-6w4m
- https://github.com/advisories/GHSA-282f-qqgm-c34q
- https://github.com/advisories/GHSA-93q8-gq69-wqmw

bumped version to 0.2.4