### PR TITLE
Refactor handling of `additionalProperties` and add support for `propertyNames`

### DIFF
--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -340,78 +340,91 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
             }
 
             md += style.bulletItem(style.propertyDetails('Required') + ': ' + summary.required, 0);
-
-            if (defined(property.exclusiveMinimum) && typeof property.exclusiveMinimum === 'number')
-            {
-                md += style.bulletItem(style.propertyDetails('Minimum') + ': ' + style.minMax(' > ' + property.exclusiveMinimum), 0);
-            } else {
-                var minimum = property.minimum;
-                if (defined(minimum)) {
-                    var exclusiveMinimum = (defined(property.exclusiveMinimum) && property.exclusiveMinimum);
-                    md += style.bulletItem(style.propertyDetails('Minimum') + ': ' + style.minMax((exclusiveMinimum ? ' > ' : ' >= ') + minimum), 0);
-                }
-            }
-
-            if (defined(property.exclusiveMaximum) && typeof property.exclusiveMaximum === 'number')
-            {
-                md += style.bulletItem(style.propertyDetails('Maximum') + ': ' + style.minMax(' < ' + property.exclusiveMaximum), 0);
-            } else {
-                var maximum = property.maximum;
-                if (defined(maximum)) {
-                    var exclusiveMaximum = (defined(property.exclusiveMaximum) && property.exclusiveMaximum);
-                    md += style.bulletItem(style.propertyDetails('Maximum') + ': ' + style.minMax((exclusiveMaximum ? ' < ' : ' <= ') + maximum), 0);
-                }
-            }
-
-            var format = property.format;
-            if (defined(format)) {
-                md += style.bulletItem(style.propertyDetails('Format') + ': ' + format, 0);
-            }
-
-            var pattern = property.pattern;
-            if (defined(pattern)) {
-                md += style.bulletItem(style.propertyDetails('Pattern') + ': ' + style.minMax(pattern), 0);
-            }
-
-            var minLength = property.minLength;
-            if (defined(minLength)) {
-                md += style.bulletItem(style.propertyDetails('Minimum Length') + style.minMax(': >= ' + minLength), 0);
-            }
-
-            var maxLength = property.maxLength;
-            if (defined(maxLength)) {
-                md += style.bulletItem(style.propertyDetails('Maximum Length') + style.minMax(': <= ' + maxLength), 0);
-            }
-
-            var enumString = getEnumString(property, type, 1);
-            if (defined(enumString)) {
-                md += style.bulletItem(style.propertyDetails('Allowed values') + ':', 0) + enumString;
-            }
-
-            if (defined(property.additionalProperties) && (typeof property.additionalProperties === 'object')) {
-                md += getAdditionalProperties(property, autoLink, 'Type of each property')
-            }
-
-            var examples = property.examples;
-            if (defined(examples)) {
-                md += style.bulletItem(style.propertyDetails('Examples') + ':');
-                for (const example of examples) {
-                    md += style.bulletItem(style.defaultValue(example, type), 1);
-                }
-            }
-
-            // TODO: Add plugin point for custom JSON schema properties like gltf_*
-            var webgl = property.gltf_webgl;
-            if (defined(webgl)) {
-                md += style.bulletItem(style.propertyGltfWebGL('Related WebGL functions') + ': ' + webgl, 0);
-            }
-
-            md += '\n';
+            md += getBasicSchemaInfo(property, summary, title, 0, knownTypes, autoLink)
         }
     }
     md += '\n';
 
     return md;
+}
+
+function getBasicSchemaInfo(property, summary, title, depth, knownTypes, autoLink) {
+    var md = ''
+
+    if (defined(property.exclusiveMinimum) && typeof property.exclusiveMinimum === 'number')
+    {
+        md += style.bulletItem(style.propertyDetails('Minimum') + ': ' + style.minMax(' > ' + property.exclusiveMinimum), depth);
+    } else {
+        var minimum = property.minimum;
+        if (defined(minimum)) {
+            var exclusiveMinimum = (defined(property.exclusiveMinimum) && property.exclusiveMinimum);
+            md += style.bulletItem(style.propertyDetails('Minimum') + ': ' + style.minMax((exclusiveMinimum ? ' > ' : ' >= ') + minimum), depth);
+        }
+    }
+
+    if (defined(property.exclusiveMaximum) && typeof property.exclusiveMaximum === 'number')
+    {
+        md += style.bulletItem(style.propertyDetails('Maximum') + ': ' + style.minMax(' < ' + property.exclusiveMaximum), depth);
+    } else {
+        var maximum = property.maximum;
+        if (defined(maximum)) {
+            var exclusiveMaximum = (defined(property.exclusiveMaximum) && property.exclusiveMaximum);
+            md += style.bulletItem(style.propertyDetails('Maximum') + ': ' + style.minMax((exclusiveMaximum ? ' < ' : ' <= ') + maximum), depth);
+        }
+    }
+
+    var format = property.format;
+    if (defined(format)) {
+        md += style.bulletItem(style.propertyDetails('Format') + ': ' + format, depth);
+    }
+
+    var pattern = property.pattern;
+    if (defined(pattern)) {
+        md += style.bulletItem(style.propertyDetails('Pattern') + ': ' + style.minMax(pattern), depth);
+    }
+
+    var minLength = property.minLength;
+    if (defined(minLength)) {
+        md += style.bulletItem(style.propertyDetails('Minimum Length') + style.minMax(': >= ' + minLength), depth);
+    }
+
+    var maxLength = property.maxLength;
+    if (defined(maxLength)) {
+        md += style.bulletItem(style.propertyDetails('Maximum Length') + style.minMax(': <= ' + maxLength), depth);
+    }
+
+    var enumString = getEnumString(property, summary.type, depth+1);
+    if (defined(enumString)) {
+        md += style.bulletItem(style.propertyDetails('Allowed values') + ':', depth) + enumString;
+    }
+
+    if (defined(property.additionalProperties) && (typeof property.additionalProperties === 'object')) {
+        md += getAdditionalProperties(property, autoLink, 'Type of each property')
+    }
+
+    if (defined(property.propertyNames)) {
+        var names = property.propertyNames
+        names.type = 'string' // property names are always strings, so usually omitted.
+        md += style.bulletItem(style.propertyDetails('Property names') + ':', depth)
+            + getBasicSchemaInfo(names, summary, title, depth+1, knownTypes, autoLink)
+    }
+    var summary = getPropertySummary(property, knownTypes, autoLink);
+
+    var examples = property.examples;
+    if (defined(examples)) {
+        md += style.bulletItem(style.propertyDetails('Examples') + ':');
+        for (const example of examples) {
+            md += style.bulletItem(style.defaultValue(example, summary.type), 1);
+        }
+    }
+
+    // TODO: Add plugin point for custom JSON schema properties like gltf_*
+    var webgl = property.gltf_webgl;
+    if (defined(webgl)) {
+        md += style.bulletItem(style.propertyGltfWebGL('Related WebGL functions') + ': ' + webgl, depth);
+    }
+
+    return md + '\n'
 }
 
 function getAdditionalProperties(schema, autoLink, detailsHeader) {

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -420,18 +420,18 @@ function getAdditionalProperties(schema, autoLink, detailsHeader) {
         return style.bulletItem(style.propertyDetails('Additional properties are not allowed.'))
     }
     if (!defined(additionalProperties) || typeof additionalProperties !== 'object') {
-        return style.bulletItem(style.propertyDetails('Additional properties are allowed.'))
+        return style.bulletItem(style.propertyDetails('Additional properties are not allowed.'))
     }
     var additionalPropertiesType = getPropertyType(additionalProperties);
     if (defined(additionalPropertiesType)) {
         // TODO: additionalProperties is really a full schema
         var formattedType = style.typeValue(additionalPropertiesType);
-        if ((additionalProperties.type === 'object') && defined(schema.title)) {
-            formattedType = style.linkType(schema.title, schema.title, autoLink);
+        if ((additionalProperties.type === 'object') && defined(additionalProperties.title)) {
+            formattedType = style.linkType(style.typeValue(additionalPropertiesType), additionalPropertiesType, autoLink);
         }
 
         return style.bulletItem(style.propertyDetails('Additional properties are allowed.'))
-            + style.bulletItem(style.propertyDetails(detailsHeader) + ': ' + formattedType, 0);
+             + style.bulletItem(style.propertyDetails(detailsHeader) + ': ' + formattedType, 0);
     }
     return ''
 }

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -199,13 +199,7 @@ function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, sche
         // Render table with summary of each property
         md += createPropertiesSummary(schema, knownTypes, autoLink);
 
-        value = schema.additionalProperties;
-        if (defined(value) && !value) {
-            md += 'Additional properties are not allowed.\n\n';
-        } else {
-            md += 'Additional properties are allowed.\n\n';
-            // TODO: display their schema
-        }
+        md += getAdditionalProperties(schema, autoLink, 'Type of additional properties')
 
         // Schema reference
         if (embedMode === enums.embedMode.referenceIncludeDocument) {
@@ -394,7 +388,9 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
                 md += style.bulletItem(style.propertyDetails('Allowed values') + ':', 0) + enumString;
             }
 
-            md += getAddtionalProperties(property, autoLink)
+            if (defined(property.additionalProperties) && (typeof property.additionalProperties === 'object')) {
+                md += getAdditionalProperties(property, autoLink, 'Type of each property')
+            }
 
             var examples = property.examples;
             if (defined(examples)) {
@@ -418,28 +414,26 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
     return md;
 }
 
-function getAddtionalProperties(schema, autoLink) {
+function getAdditionalProperties(schema, autoLink, detailsHeader) {
     var additionalProperties = schema.additionalProperties;
-    if (!defined(additionalProperties)) {
-        return ''
+    if (defined(additionalProperties) && !additionalProperties) {
+        return style.bulletItem(style.propertyDetails('Additional properties are not allowed.'))
     }
-    if (typeof additionalProperties === 'boolean') {
-        return 'Additional properties are ' + (additionalProperties ? ' ' : ' not ') + 'allowed.\n\n'
+    if (!defined(additionalProperties) || typeof additionalProperties !== 'object') {
+        return style.bulletItem(style.propertyDetails('Additional properties are allowed.'))
     }
-    var md = ''
-    if (defined(additionalProperties) && (typeof additionalProperties === 'object')) {
-        var additionalPropertiesType = getPropertyType(additionalProperties);
-        if (defined(additionalPropertiesType)) {
-            // TODO: additionalProperties is really a full schema
-            var formattedType = style.typeValue(additionalPropertiesType);
-            if ((additionalProperties.type === 'object') && defined(schema.title)) {
-                formattedType = style.linkType(schema.title, schema.title, autoLink);
-            }
-
-            md += style.bulletItem(style.propertyDetails('Type of each property') + ': ' + formattedType, 0);
+    var additionalPropertiesType = getPropertyType(additionalProperties);
+    if (defined(additionalPropertiesType)) {
+        // TODO: additionalProperties is really a full schema
+        var formattedType = style.typeValue(additionalPropertiesType);
+        if ((additionalProperties.type === 'object') && defined(schema.title)) {
+            formattedType = style.linkType(schema.title, schema.title, autoLink);
         }
+
+        return style.bulletItem(style.propertyDetails('Additional properties are allowed.'))
+            + style.bulletItem(style.propertyDetails(detailsHeader) + ': ' + formattedType, 0);
     }
-    return md
+    return ''
 }
 
 

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -440,8 +440,13 @@ function getAdditionalProperties(schema, autoLink, detailsHeader) {
         // TODO: additionalProperties is really a full schema
         var formattedType = style.typeValue(additionalPropertiesType);
         if ((additionalProperties.type === 'object') && defined(additionalProperties.title)) {
-            formattedType = style.linkType(style.typeValue(additionalPropertiesType), additionalPropertiesType, autoLink);
+            formattedType = style.linkType(formattedType, additionalPropertiesType, autoLink);
         }
+        // XXX Previous method, but it showed the type of the parent, which is not right.
+        // Left for future reference and/or repairs.
+        // if ((additionalProperties.type === 'object') && defined(schema.title)) {
+        //     formattedType = style.linkType(schema.title, schema.title, autoLink);
+        // }
 
         return style.bulletItem(style.propertyDetails('Additional properties are allowed.'))
              + style.bulletItem(style.propertyDetails(detailsHeader) + ': ' + formattedType, 0);

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -394,19 +394,7 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
                 md += style.bulletItem(style.propertyDetails('Allowed values') + ':', 0) + enumString;
             }
 
-            var additionalProperties = property.additionalProperties;
-            if (defined(additionalProperties) && (typeof additionalProperties === 'object')) {
-                var additionalPropertiesType = getPropertyType(additionalProperties);
-                if (defined(additionalPropertiesType)) {
-                    // TODO: additionalProperties is really a full schema
-                    var formattedType = style.typeValue(additionalPropertiesType);
-                    if ((additionalProperties.type === 'object') && defined(property.title)) {
-                        formattedType = style.linkType(property.title, property.title, autoLink);
-                    }
-
-                    md += style.bulletItem(style.propertyDetails('Type of each property') + ': ' + formattedType, 0);
-                }
-            }
+            md += getAddtionalProperties(property, autoLink)
 
             var examples = property.examples;
             if (defined(examples)) {
@@ -429,6 +417,31 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
 
     return md;
 }
+
+function getAddtionalProperties(schema, autoLink) {
+    var additionalProperties = schema.additionalProperties;
+    if (!defined(additionalProperties)) {
+        return ''
+    }
+    if (typeof additionalProperties === 'boolean') {
+        return 'Additional properties are ' + (additionalProperties ? ' ' : ' not ') + 'allowed.\n\n'
+    }
+    var md = ''
+    if (defined(additionalProperties) && (typeof additionalProperties === 'object')) {
+        var additionalPropertiesType = getPropertyType(additionalProperties);
+        if (defined(additionalPropertiesType)) {
+            // TODO: additionalProperties is really a full schema
+            var formattedType = style.typeValue(additionalPropertiesType);
+            if ((additionalProperties.type === 'object') && defined(schema.title)) {
+                formattedType = style.linkType(schema.title, schema.title, autoLink);
+            }
+
+            md += style.bulletItem(style.propertyDetails('Type of each property') + ': ' + formattedType, 0);
+        }
+    }
+    return md
+}
+
 
 function getPropertySummary(property, knownTypes, autoLink) {
     var type = defaultValue(getPropertyType(property), 'any');

--- a/test/test-golden/example-embed.adoc
+++ b/test/test-golden/example-embed.adoc
@@ -22,8 +22,7 @@ Example description.
 
 |===
 
-Additional properties are not allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: <<schema-reference-example,`example.schema.json`>>
 
 === example.byteOffset

--- a/test/test-golden/example-keyword.md
+++ b/test/test-golden/example-keyword.md
@@ -15,8 +15,7 @@ Example description.
 |**byteOffset**|`integer`|The offset relative to the start of the buffer in bytes.|No, default: `0`|
 |**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &#10003; Yes|
 
-Additional properties are not allowed.
-
+* **Additional properties are not allowed.**
 ### example.byteOffset
 
 The offset relative to the start of the buffer in bytes.

--- a/test/test-golden/example-linked.adoc
+++ b/test/test-golden/example-linked.adoc
@@ -24,8 +24,7 @@ Example description.
 
 |===
 
-Additional properties are not allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: link:schema/example.schema.json[example.schema.json]
 
 ==== example.byteOffset

--- a/test/test-golden/example-linked.md
+++ b/test/test-golden/example-linked.md
@@ -15,8 +15,7 @@ Example description.
 |**byteOffset**|`integer`|The offset relative to the start of the buffer in bytes.|No, default: `0`|
 |**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &#10003; Yes|
 
-Additional properties are not allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: [example.schema.json](schema/example.schema.json)
 
 #### example.byteOffset

--- a/test/test-golden/example-remote.adoc
+++ b/test/test-golden/example-remote.adoc
@@ -22,8 +22,7 @@ Example description.
 
 |===
 
-Additional properties are not allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/example.schema.json[example.schema.json]
 
 === example.byteOffset

--- a/test/test-golden/example-remote.md
+++ b/test/test-golden/example-remote.md
@@ -13,8 +13,7 @@ Example description.
 |**byteOffset**|`integer`|The offset relative to the start of the buffer in bytes.|No, default: `0`|
 |**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &#10003; Yes|
 
-Additional properties are not allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: [example.schema.json](https://www.khronos.org/wetzel/just/testing/schema/example.schema.json)
 
 ### example.byteOffset

--- a/test/test-golden/example-simple.adoc
+++ b/test/test-golden/example-simple.adoc
@@ -24,8 +24,7 @@ Example description.
 
 |===
 
-Additional properties are not allowed.
-
+* **Additional properties are not allowed.**
 === example.byteOffset
 
 The offset relative to the start of the buffer in bytes.

--- a/test/test-golden/example-simple.md
+++ b/test/test-golden/example-simple.md
@@ -15,8 +15,7 @@ Example description.
 |**byteOffset**|`integer`|The offset relative to the start of the buffer in bytes.|No, default: `0`|
 |**type**|`string`|Specifies if the elements are scalars, vectors, or matrices.| &#10003; Yes|
 
-Additional properties are not allowed.
-
+* **Additional properties are not allowed.**
 ### example.byteOffset
 
 The offset relative to the start of the buffer in bytes.

--- a/test/test-golden/nested-embed.adoc
+++ b/test/test-golden/nested-embed.adoc
@@ -47,8 +47,7 @@ A view into a buffer.
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: <<schema-reference-bufferview,`bufferView.schema.json`>>
 
 === bufferView.byteOffset
@@ -101,7 +100,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 === bufferView.extras
 
@@ -119,8 +119,8 @@ Application-specific data.
 
 Dictionary object with extension-specific objects.
 
-Additional properties are allowed.
-
+* **Additional properties are allowed.**
+* **Type of additional properties**: `object`
 * **JSON schema**: <<schema-reference-extension,`extension.schema.json`>>
 
 
@@ -183,8 +183,7 @@ Image data used to create a texture. Image can be referenced by URI or `bufferVi
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: <<schema-reference-image,`image.schema.json`>>
 
 === image.uri
@@ -235,7 +234,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 === image.extras
 
@@ -299,8 +299,7 @@ The material appearance of a primitive.
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: <<schema-reference-material,`material.schema.json`>>
 
 === material.name
@@ -316,7 +315,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 === material.extras
 
@@ -406,8 +406,7 @@ A set of parameter values that are used to define the metallic-roughness materia
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: <<schema-reference-material-pbrmetallicroughness,`material.pbrMetallicRoughness.schema.json`>>
 
 === material.pbrMetallicRoughness.baseColorFactor
@@ -442,7 +441,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 === material.pbrMetallicRoughness.extras
 
@@ -501,8 +501,7 @@ The root object for a nestedTest asset.
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: <<schema-reference-nestedtest,`nestedTest.schema.json`>>
 
 === nestedTest.bufferViews
@@ -548,7 +547,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 === nestedTest.extras
 

--- a/test/test-golden/nested-keyword.md
+++ b/test/test-golden/nested-keyword.md
@@ -26,8 +26,7 @@ A view into a buffer.
 |**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
 |**extras**|`extras`|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 ### bufferView.byteOffset
 
 The offset into the buffer in bytes.
@@ -78,7 +77,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ### bufferView.extras
 
@@ -96,8 +96,8 @@ Application-specific data.
 
 Dictionary object with extension-specific objects.
 
-Additional properties are allowed.
-
+* **Additional properties are allowed.**
+* **Type of additional properties**: `object`
 
 
 
@@ -129,8 +129,7 @@ Image data used to create a texture. Image can be referenced by URI or `bufferVi
 |**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
 |**extras**|`extras`|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 ### image.uri
 
 The uri of the image.  This is the detailed description of the property.
@@ -179,7 +178,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ### image.extras
 
@@ -210,8 +210,7 @@ The material appearance of a primitive.
 |**alphaCutoff**|`number`|The alpha cutoff value of the material.|No, default: `0.5`|
 |**doubleSided**|`boolean`|Specifies whether the material is double sided.|No, default: `false`|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 ### material.name
 
 The user-defined name of this object.  This is the detailed description of the property.
@@ -225,7 +224,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ### material.extras
 
@@ -294,8 +294,7 @@ A set of parameter values that are used to define the metallic-roughness materia
 |**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
 |**extras**|`extras`|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 ### material.pbrMetallicRoughness.baseColorFactor
 
 The RGBA components of the base color of the material. This is the detailed description of the property.
@@ -328,7 +327,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ### material.pbrMetallicRoughness.extras
 
@@ -358,8 +358,7 @@ The root object for a nestedTest asset.
 |**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
 |**extras**|`extras`|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 ### nestedTest.bufferViews
 
 An array of bufferViews.  This is the detailed description of the property.
@@ -403,7 +402,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ### nestedTest.extras
 

--- a/test/test-golden/nested-linked.adoc
+++ b/test/test-golden/nested-linked.adoc
@@ -55,8 +55,7 @@ A view into a buffer.
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: link:schema/bufferView.schema.json[bufferView.schema.json]
 
 ==== bufferView.byteOffset
@@ -109,7 +108,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ==== bufferView.extras
 
@@ -127,8 +127,8 @@ Application-specific data.
 
 Dictionary object with extension-specific objects.
 
-Additional properties are allowed.
-
+* **Additional properties are allowed.**
+* **Type of additional properties**: `object`
 * **JSON schema**: link:schema/extension.schema.json[extension.schema.json]
 
 
@@ -191,8 +191,7 @@ Image data used to create a texture. Image can be referenced by URI or `bufferVi
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: link:schema/image.schema.json[image.schema.json]
 
 ==== image.uri
@@ -243,7 +242,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ==== image.extras
 
@@ -307,8 +307,7 @@ The material appearance of a primitive.
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: link:schema/material.schema.json[material.schema.json]
 
 ==== material.name
@@ -324,7 +323,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ==== material.extras
 
@@ -414,8 +414,7 @@ A set of parameter values that are used to define the metallic-roughness materia
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: link:schema/material.pbrMetallicRoughness.schema.json[material.pbrMetallicRoughness.schema.json]
 
 ==== material.pbrMetallicRoughness.baseColorFactor
@@ -450,7 +449,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ==== material.pbrMetallicRoughness.extras
 
@@ -509,8 +509,7 @@ The root object for a nestedTest asset.
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: link:schema/nestedTest.schema.json[nestedTest.schema.json]
 
 ==== nestedTest.bufferViews
@@ -556,7 +555,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ==== nestedTest.extras
 

--- a/test/test-golden/nested-linked.md
+++ b/test/test-golden/nested-linked.md
@@ -26,8 +26,7 @@ A view into a buffer.
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: [bufferView.schema.json](schema/bufferView.schema.json)
 
 #### bufferView.byteOffset
@@ -80,7 +79,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 #### bufferView.extras
 
@@ -98,8 +98,8 @@ Application-specific data.
 
 Dictionary object with extension-specific objects.
 
-Additional properties are allowed.
-
+* **Additional properties are allowed.**
+* **Type of additional properties**: `object`
 * **JSON schema**: [extension.schema.json](schema/extension.schema.json)
 
 
@@ -133,8 +133,7 @@ Image data used to create a texture. Image can be referenced by URI or `bufferVi
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: [image.schema.json](schema/image.schema.json)
 
 #### image.uri
@@ -185,7 +184,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 #### image.extras
 
@@ -216,8 +216,7 @@ The material appearance of a primitive.
 |**alphaCutoff**|`number`|The alpha cutoff value of the material.|No, default: `0.5`|
 |**doubleSided**|`boolean`|Specifies whether the material is double sided.|No, default: `false`|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: [material.schema.json](schema/material.schema.json)
 
 #### material.name
@@ -233,7 +232,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 #### material.extras
 
@@ -302,8 +302,7 @@ A set of parameter values that are used to define the metallic-roughness materia
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: [material.pbrMetallicRoughness.schema.json](schema/material.pbrMetallicRoughness.schema.json)
 
 #### material.pbrMetallicRoughness.baseColorFactor
@@ -338,7 +337,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 #### material.pbrMetallicRoughness.extras
 
@@ -368,8 +368,7 @@ The root object for a nestedTest asset.
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: [nestedTest.schema.json](schema/nestedTest.schema.json)
 
 #### nestedTest.bufferViews
@@ -415,7 +414,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 #### nestedTest.extras
 

--- a/test/test-golden/nested-remote.adoc
+++ b/test/test-golden/nested-remote.adoc
@@ -47,8 +47,7 @@ A view into a buffer.
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/bufferView.schema.json[bufferView.schema.json]
 
 === bufferView.byteOffset
@@ -101,7 +100,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 === bufferView.extras
 
@@ -119,8 +119,8 @@ Application-specific data.
 
 Dictionary object with extension-specific objects.
 
-Additional properties are allowed.
-
+* **Additional properties are allowed.**
+* **Type of additional properties**: `object`
 * **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/extension.schema.json[extension.schema.json]
 
 
@@ -183,8 +183,7 @@ Image data used to create a texture. Image can be referenced by URI or `bufferVi
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/image.schema.json[image.schema.json]
 
 === image.uri
@@ -235,7 +234,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 === image.extras
 
@@ -299,8 +299,7 @@ The material appearance of a primitive.
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/material.schema.json[material.schema.json]
 
 === material.name
@@ -316,7 +315,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 === material.extras
 
@@ -406,8 +406,7 @@ A set of parameter values that are used to define the metallic-roughness materia
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/material.pbrMetallicRoughness.schema.json[material.pbrMetallicRoughness.schema.json]
 
 === material.pbrMetallicRoughness.baseColorFactor
@@ -442,7 +441,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 === material.pbrMetallicRoughness.extras
 
@@ -501,8 +501,7 @@ The root object for a nestedTest asset.
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/nestedTest.schema.json[nestedTest.schema.json]
 
 === nestedTest.bufferViews
@@ -548,7 +547,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 === nestedTest.extras
 

--- a/test/test-golden/nested-remote.md
+++ b/test/test-golden/nested-remote.md
@@ -18,8 +18,7 @@ A view into a buffer.
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: [bufferView.schema.json](https://www.khronos.org/wetzel/just/testing/schema/bufferView.schema.json)
 
 ### bufferView.byteOffset
@@ -72,7 +71,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ### bufferView.extras
 
@@ -90,8 +90,8 @@ Application-specific data.
 
 Dictionary object with extension-specific objects.
 
-Additional properties are allowed.
-
+* **Additional properties are allowed.**
+* **Type of additional properties**: `object`
 * **JSON schema**: [extension.schema.json](https://www.khronos.org/wetzel/just/testing/schema/extension.schema.json)
 
 
@@ -125,8 +125,7 @@ Image data used to create a texture. Image can be referenced by URI or `bufferVi
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: [image.schema.json](https://www.khronos.org/wetzel/just/testing/schema/image.schema.json)
 
 ### image.uri
@@ -177,7 +176,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ### image.extras
 
@@ -208,8 +208,7 @@ The material appearance of a primitive.
 |**alphaCutoff**|`number`|The alpha cutoff value of the material.|No, default: `0.5`|
 |**doubleSided**|`boolean`|Specifies whether the material is double sided.|No, default: `false`|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: [material.schema.json](https://www.khronos.org/wetzel/just/testing/schema/material.schema.json)
 
 ### material.name
@@ -225,7 +224,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ### material.extras
 
@@ -294,8 +294,7 @@ A set of parameter values that are used to define the metallic-roughness materia
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: [material.pbrMetallicRoughness.schema.json](https://www.khronos.org/wetzel/just/testing/schema/material.pbrMetallicRoughness.schema.json)
 
 ### material.pbrMetallicRoughness.baseColorFactor
@@ -330,7 +329,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ### material.pbrMetallicRoughness.extras
 
@@ -360,8 +360,7 @@ The root object for a nestedTest asset.
 |**extensions**|[`extension`](#reference-extension)|Dictionary object with extension-specific objects.|No|
 |**extras**|[`extras`](#reference-extras)|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: [nestedTest.schema.json](https://www.khronos.org/wetzel/just/testing/schema/nestedTest.schema.json)
 
 ### nestedTest.bufferViews
@@ -407,7 +406,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ### nestedTest.extras
 

--- a/test/test-golden/nested-simple.adoc
+++ b/test/test-golden/nested-simple.adoc
@@ -55,8 +55,7 @@ A view into a buffer.
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 === bufferView.byteOffset
 
 The offset into the buffer in bytes.
@@ -107,7 +106,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 === bufferView.extras
 
@@ -125,8 +125,8 @@ Application-specific data.
 
 Dictionary object with extension-specific objects.
 
-Additional properties are allowed.
-
+* **Additional properties are allowed.**
+* **Type of additional properties**: `object`
 
 
 
@@ -187,8 +187,7 @@ Image data used to create a texture. Image can be referenced by URI or `bufferVi
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 === image.uri
 
 The uri of the image.  This is the detailed description of the property.
@@ -237,7 +236,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 === image.extras
 
@@ -301,8 +301,7 @@ The material appearance of a primitive.
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 === material.name
 
 The user-defined name of this object.  This is the detailed description of the property.
@@ -316,7 +315,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 === material.extras
 
@@ -406,8 +406,7 @@ A set of parameter values that are used to define the metallic-roughness materia
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 === material.pbrMetallicRoughness.baseColorFactor
 
 The RGBA components of the base color of the material. This is the detailed description of the property.
@@ -440,7 +439,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 === material.pbrMetallicRoughness.extras
 
@@ -499,8 +499,7 @@ The root object for a nestedTest asset.
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 === nestedTest.bufferViews
 
 An array of bufferViews.  This is the detailed description of the property.
@@ -544,7 +543,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 === nestedTest.extras
 

--- a/test/test-golden/nested-simple.md
+++ b/test/test-golden/nested-simple.md
@@ -26,8 +26,7 @@ A view into a buffer.
 |**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
 |**extras**|`extras`|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 ### bufferView.byteOffset
 
 The offset into the buffer in bytes.
@@ -78,7 +77,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ### bufferView.extras
 
@@ -96,8 +96,8 @@ Application-specific data.
 
 Dictionary object with extension-specific objects.
 
-Additional properties are allowed.
-
+* **Additional properties are allowed.**
+* **Type of additional properties**: `object`
 
 
 
@@ -129,8 +129,7 @@ Image data used to create a texture. Image can be referenced by URI or `bufferVi
 |**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
 |**extras**|`extras`|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 ### image.uri
 
 The uri of the image.  This is the detailed description of the property.
@@ -179,7 +178,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ### image.extras
 
@@ -210,8 +210,7 @@ The material appearance of a primitive.
 |**alphaCutoff**|`number`|The alpha cutoff value of the material.|No, default: `0.5`|
 |**doubleSided**|`boolean`|Specifies whether the material is double sided.|No, default: `false`|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 ### material.name
 
 The user-defined name of this object.  This is the detailed description of the property.
@@ -225,7 +224,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ### material.extras
 
@@ -294,8 +294,7 @@ A set of parameter values that are used to define the metallic-roughness materia
 |**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
 |**extras**|`extras`|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 ### material.pbrMetallicRoughness.baseColorFactor
 
 The RGBA components of the base color of the material. This is the detailed description of the property.
@@ -328,7 +327,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ### material.pbrMetallicRoughness.extras
 
@@ -358,8 +358,7 @@ The root object for a nestedTest asset.
 |**extensions**|`extension`|Dictionary object with extension-specific objects.|No|
 |**extras**|`extras`|Application-specific data.|No|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 ### nestedTest.bufferViews
 
 An array of bufferViews.  This is the detailed description of the property.
@@ -403,7 +402,8 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Additional properties are allowed.**
+* **Type of each property**: `object`
 
 ### nestedTest.extras
 

--- a/test/test-golden/v2020-12-embed.adoc
+++ b/test/test-golden/v2020-12-embed.adoc
@@ -37,8 +37,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: <<schema-reference-image,`image.schema.json`>>
 
 === Image.uri

--- a/test/test-golden/v2020-12-embed.adoc
+++ b/test/test-golden/v2020-12-embed.adoc
@@ -35,6 +35,11 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |An array of three fractional numbers.
 |No, default: `[0.1,0.2,0.3]`
 
+|**metadata**
+|`object`
+|
+|No
+
 |===
 
 * **Additional properties are not allowed.**
@@ -91,8 +96,64 @@ An array of three fractional numbers.
 ** `[1.3, 4.03, 42]`
 ** `[18, 0.1, 1.1]`
 
+=== Image.metadata
+
+* **Type**: `object`
+* **Required**: No
+* **Additional properties are allowed.**
+* **Type of each property**: <<reference-meta,`meta`>>
+* **Property names**:
+** **Pattern**: `^[A-Za-z_][A-Za-z0-9_]*$`
+** **Minimum Length**`: &gt;= 3`
+** **Maximum Length**`: &lt;= 10`
+** **Allowed values**:
+*** `aperture`
+*** `camera`
+*** `lens`
+
+
 
 == Examples
 
 * `{"uri": "https://raw.githubusercontent.com/KhronosGroup/glTF/main/specification/figures/gltf.png", "mimeType": "image/png"}`
 * `{"bufferView": 2, "fraction": 0.3, "moreFractions": [  1.1,  2.2,  3.3 ]}`
+
+
+
+
+'''
+[#reference-meta]
+== Metadatum
+
+A random piece of image metadata
+
+.`Metadatum` Properties
+|===
+|   |Type|Description|Required
+
+|**key**
+|`string`
+|
+| &#10003; Yes
+
+|**val**
+|`string`
+|
+| &#10003; Yes
+
+|===
+
+* **Additional properties are not allowed.**
+* **JSON schema**: <<schema-reference-meta,`meta.schema.json`>>
+
+=== meta.key
+
+* **Type**: `string`
+* **Required**:  &#10003; Yes
+
+=== meta.val
+
+* **Type**: `string`
+* **Required**:  &#10003; Yes
+
+

--- a/test/test-golden/v2020-12-embedJSON.adoc
+++ b/test/test-golden/v2020-12-embedJSON.adoc
@@ -9,3 +9,16 @@ include::schema/image.schema.json[]
 ----
 
 <<<
+
+
+
+
+[#schema-reference-meta]
+== JSON Schema for Metadatum
+
+[source,json]
+----
+include::schema/meta.schema.json[]
+----
+
+<<<

--- a/test/test-golden/v2020-12-keyword.md
+++ b/test/test-golden/v2020-12-keyword.md
@@ -18,8 +18,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |**fraction**|`number`|A number that **MUST** be between zero and one.|No|
 |**moreFractions**|`number` `[3]`|An array of three fractional numbers.|No, default: `[0.1,0.2,0.3]`|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 ### Image.uri
 
 The URI (or IRI) of the image.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.

--- a/test/test-golden/v2020-12-keyword.md
+++ b/test/test-golden/v2020-12-keyword.md
@@ -17,6 +17,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |**bufferView**|`integer`|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.|No|
 |**fraction**|`number`|A number that **MUST** be between zero and one.|No|
 |**moreFractions**|`number` `[3]`|An array of three fractional numbers.|No, default: `[0.1,0.2,0.3]`|
+|**metadata**|`object`||No|
 
 * **Additional properties are not allowed.**
 ### Image.uri
@@ -70,8 +71,53 @@ An array of three fractional numbers.
     * `[1.3, 4.03, 42]`
     * `[18, 0.1, 1.1]`
 
+### Image.metadata
+
+* **Type**: `object`
+* **Required**: No
+* **Additional properties are allowed.**
+* **Type of each property**: `meta`
+* **Property names**:
+    * **Pattern**: `^[A-Za-z_][A-Za-z0-9_]*$`
+    * **Minimum Length**`: >= 3`
+    * **Maximum Length**`: <= 10`
+    * **Allowed values**:
+        * `aperture`
+        * `camera`
+        * `lens`
+
+
 
 ## Examples
 
 * `{"uri": "https://raw.githubusercontent.com/KhronosGroup/glTF/main/specification/figures/gltf.png", "mimeType": "image/png"}`
 * `{"bufferView": 2, "fraction": 0.3, "moreFractions": [  1.1,  2.2,  3.3 ]}`
+
+
+
+
+---------------------------------------
+<a name="reference-meta"></a>
+## Metadatum
+
+A random piece of image metadata
+
+**`Metadatum` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**key**|`string`|| &#10003; Yes|
+|**val**|`string`|| &#10003; Yes|
+
+* **Additional properties are not allowed.**
+### meta.key
+
+* **Type**: `string`
+* **Required**:  &#10003; Yes
+
+### meta.val
+
+* **Type**: `string`
+* **Required**:  &#10003; Yes
+
+

--- a/test/test-golden/v2020-12-linked.adoc
+++ b/test/test-golden/v2020-12-linked.adoc
@@ -39,8 +39,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: link:schema/image.schema.json[image.schema.json]
 
 ==== Image.uri

--- a/test/test-golden/v2020-12-linked.adoc
+++ b/test/test-golden/v2020-12-linked.adoc
@@ -37,6 +37,11 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |An array of three fractional numbers.
 |No, default: `[0.1,0.2,0.3]`
 
+|**metadata**
+|`object`
+|
+|No
+
 |===
 
 * **Additional properties are not allowed.**
@@ -93,8 +98,64 @@ An array of three fractional numbers.
 ** `[1.3, 4.03, 42]`
 ** `[18, 0.1, 1.1]`
 
+==== Image.metadata
+
+* **Type**: `object`
+* **Required**: No
+* **Additional properties are allowed.**
+* **Type of each property**: <<reference-meta,`meta`>>
+* **Property names**:
+** **Pattern**: `^[A-Za-z_][A-Za-z0-9_]*$`
+** **Minimum Length**`: &gt;= 3`
+** **Maximum Length**`: &lt;= 10`
+** **Allowed values**:
+*** `aperture`
+*** `camera`
+*** `lens`
+
+
 
 === Examples
 
 * `{"uri": "https://raw.githubusercontent.com/KhronosGroup/glTF/main/specification/figures/gltf.png", "mimeType": "image/png"}`
 * `{"bufferView": 2, "fraction": 0.3, "moreFractions": [  1.1,  2.2,  3.3 ]}`
+
+
+
+
+'''
+[#reference-meta]
+=== Metadatum
+
+A random piece of image metadata
+
+.`Metadatum` Properties
+|===
+|   |Type|Description|Required
+
+|**key**
+|`string`
+|
+| icon:check[] Yes
+
+|**val**
+|`string`
+|
+| icon:check[] Yes
+
+|===
+
+* **Additional properties are not allowed.**
+* **JSON schema**: link:schema/meta.schema.json[meta.schema.json]
+
+==== meta.key
+
+* **Type**: `string`
+* **Required**:  icon:check[] Yes
+
+==== meta.val
+
+* **Type**: `string`
+* **Required**:  icon:check[] Yes
+
+

--- a/test/test-golden/v2020-12-linked.md
+++ b/test/test-golden/v2020-12-linked.md
@@ -18,8 +18,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |**fraction**|`number`|A number that **MUST** be between zero and one.|No|
 |**moreFractions**|`number` `[3]`|An array of three fractional numbers.|No, default: `[0.1,0.2,0.3]`|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: [image.schema.json](schema/image.schema.json)
 
 #### Image.uri

--- a/test/test-golden/v2020-12-linked.md
+++ b/test/test-golden/v2020-12-linked.md
@@ -17,6 +17,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |**bufferView**|`integer`|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.|No|
 |**fraction**|`number`|A number that **MUST** be between zero and one.|No|
 |**moreFractions**|`number` `[3]`|An array of three fractional numbers.|No, default: `[0.1,0.2,0.3]`|
+|**metadata**|`object`||No|
 
 * **Additional properties are not allowed.**
 * **JSON schema**: [image.schema.json](schema/image.schema.json)
@@ -72,8 +73,55 @@ An array of three fractional numbers.
     * `[1.3, 4.03, 42]`
     * `[18, 0.1, 1.1]`
 
+#### Image.metadata
+
+* **Type**: `object`
+* **Required**: No
+* **Additional properties are allowed.**
+* **Type of each property**: [`meta`](#reference-meta)
+* **Property names**:
+    * **Pattern**: `^[A-Za-z_][A-Za-z0-9_]*$`
+    * **Minimum Length**`: >= 3`
+    * **Maximum Length**`: <= 10`
+    * **Allowed values**:
+        * `aperture`
+        * `camera`
+        * `lens`
+
+
 
 ### Examples
 
 * `{"uri": "https://raw.githubusercontent.com/KhronosGroup/glTF/main/specification/figures/gltf.png", "mimeType": "image/png"}`
 * `{"bufferView": 2, "fraction": 0.3, "moreFractions": [  1.1,  2.2,  3.3 ]}`
+
+
+
+
+---------------------------------------
+<a name="reference-meta"></a>
+### Metadatum
+
+A random piece of image metadata
+
+**`Metadatum` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**key**|`string`|| &#10003; Yes|
+|**val**|`string`|| &#10003; Yes|
+
+* **Additional properties are not allowed.**
+* **JSON schema**: [meta.schema.json](schema/meta.schema.json)
+
+#### meta.key
+
+* **Type**: `string`
+* **Required**:  &#10003; Yes
+
+#### meta.val
+
+* **Type**: `string`
+* **Required**:  &#10003; Yes
+
+

--- a/test/test-golden/v2020-12-remote.adoc
+++ b/test/test-golden/v2020-12-remote.adoc
@@ -37,8 +37,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/image.schema.json[image.schema.json]
 
 === Image.uri

--- a/test/test-golden/v2020-12-remote.adoc
+++ b/test/test-golden/v2020-12-remote.adoc
@@ -35,6 +35,11 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |An array of three fractional numbers.
 |No, default: `[0.1,0.2,0.3]`
 
+|**metadata**
+|`object`
+|
+|No
+
 |===
 
 * **Additional properties are not allowed.**
@@ -91,8 +96,64 @@ An array of three fractional numbers.
 ** `[1.3, 4.03, 42]`
 ** `[18, 0.1, 1.1]`
 
+=== Image.metadata
+
+* **Type**: `object`
+* **Required**: No
+* **Additional properties are allowed.**
+* **Type of each property**: <<reference-meta,`meta`>>
+* **Property names**:
+** **Pattern**: `^[A-Za-z_][A-Za-z0-9_]*$`
+** **Minimum Length**`: &gt;= 3`
+** **Maximum Length**`: &lt;= 10`
+** **Allowed values**:
+*** `aperture`
+*** `camera`
+*** `lens`
+
+
 
 == Examples
 
 * `{"uri": "https://raw.githubusercontent.com/KhronosGroup/glTF/main/specification/figures/gltf.png", "mimeType": "image/png"}`
 * `{"bufferView": 2, "fraction": 0.3, "moreFractions": [  1.1,  2.2,  3.3 ]}`
+
+
+
+
+'''
+[#reference-meta]
+== Metadatum
+
+A random piece of image metadata
+
+.`Metadatum` Properties
+|===
+|   |Type|Description|Required
+
+|**key**
+|`string`
+|
+| &#10003; Yes
+
+|**val**
+|`string`
+|
+| &#10003; Yes
+
+|===
+
+* **Additional properties are not allowed.**
+* **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/meta.schema.json[meta.schema.json]
+
+=== meta.key
+
+* **Type**: `string`
+* **Required**:  &#10003; Yes
+
+=== meta.val
+
+* **Type**: `string`
+* **Required**:  &#10003; Yes
+
+

--- a/test/test-golden/v2020-12-remote.md
+++ b/test/test-golden/v2020-12-remote.md
@@ -16,8 +16,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |**fraction**|`number`|A number that **MUST** be between zero and one.|No|
 |**moreFractions**|`number` `[3]`|An array of three fractional numbers.|No, default: `[0.1,0.2,0.3]`|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 * **JSON schema**: [image.schema.json](https://www.khronos.org/wetzel/just/testing/schema/image.schema.json)
 
 ### Image.uri

--- a/test/test-golden/v2020-12-remote.md
+++ b/test/test-golden/v2020-12-remote.md
@@ -15,6 +15,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |**bufferView**|`integer`|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.|No|
 |**fraction**|`number`|A number that **MUST** be between zero and one.|No|
 |**moreFractions**|`number` `[3]`|An array of three fractional numbers.|No, default: `[0.1,0.2,0.3]`|
+|**metadata**|`object`||No|
 
 * **Additional properties are not allowed.**
 * **JSON schema**: [image.schema.json](https://www.khronos.org/wetzel/just/testing/schema/image.schema.json)
@@ -70,8 +71,55 @@ An array of three fractional numbers.
     * `[1.3, 4.03, 42]`
     * `[18, 0.1, 1.1]`
 
+### Image.metadata
+
+* **Type**: `object`
+* **Required**: No
+* **Additional properties are allowed.**
+* **Type of each property**: [`meta`](#reference-meta)
+* **Property names**:
+    * **Pattern**: `^[A-Za-z_][A-Za-z0-9_]*$`
+    * **Minimum Length**`: >= 3`
+    * **Maximum Length**`: <= 10`
+    * **Allowed values**:
+        * `aperture`
+        * `camera`
+        * `lens`
+
+
 
 ## Examples
 
 * `{"uri": "https://raw.githubusercontent.com/KhronosGroup/glTF/main/specification/figures/gltf.png", "mimeType": "image/png"}`
 * `{"bufferView": 2, "fraction": 0.3, "moreFractions": [  1.1,  2.2,  3.3 ]}`
+
+
+
+
+---------------------------------------
+<a name="reference-meta"></a>
+## Metadatum
+
+A random piece of image metadata
+
+**`Metadatum` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**key**|`string`|| &#10003; Yes|
+|**val**|`string`|| &#10003; Yes|
+
+* **Additional properties are not allowed.**
+* **JSON schema**: [meta.schema.json](https://www.khronos.org/wetzel/just/testing/schema/meta.schema.json)
+
+### meta.key
+
+* **Type**: `string`
+* **Required**:  &#10003; Yes
+
+### meta.val
+
+* **Type**: `string`
+* **Required**:  &#10003; Yes
+
+

--- a/test/test-golden/v2020-12-simple.adoc
+++ b/test/test-golden/v2020-12-simple.adoc
@@ -39,8 +39,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 
 |===
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 === Image.uri
 
 The URI (or IRI) of the image.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.

--- a/test/test-golden/v2020-12-simple.adoc
+++ b/test/test-golden/v2020-12-simple.adoc
@@ -37,6 +37,11 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |An array of three fractional numbers.
 |No, default: `[0.1,0.2,0.3]`
 
+|**metadata**
+|`object`
+|
+|No
+
 |===
 
 * **Additional properties are not allowed.**
@@ -91,8 +96,62 @@ An array of three fractional numbers.
 ** `[1.3, 4.03, 42]`
 ** `[18, 0.1, 1.1]`
 
+=== Image.metadata
+
+* **Type**: `object`
+* **Required**: No
+* **Additional properties are allowed.**
+* **Type of each property**: `meta`
+* **Property names**:
+** **Pattern**: `^[A-Za-z_][A-Za-z0-9_]*$`
+** **Minimum Length**`: &gt;= 3`
+** **Maximum Length**`: &lt;= 10`
+** **Allowed values**:
+*** `aperture`
+*** `camera`
+*** `lens`
+
+
 
 == Examples
 
 * `{"uri": "https://raw.githubusercontent.com/KhronosGroup/glTF/main/specification/figures/gltf.png", "mimeType": "image/png"}`
 * `{"bufferView": 2, "fraction": 0.3, "moreFractions": [  1.1,  2.2,  3.3 ]}`
+
+
+
+
+'''
+[#reference-meta]
+== Metadatum
+
+A random piece of image metadata
+
+.`Metadatum` Properties
+|===
+|   |Type|Description|Required
+
+|**key**
+|`string`
+|
+| &#10003; Yes
+
+|**val**
+|`string`
+|
+| &#10003; Yes
+
+|===
+
+* **Additional properties are not allowed.**
+=== meta.key
+
+* **Type**: `string`
+* **Required**:  &#10003; Yes
+
+=== meta.val
+
+* **Type**: `string`
+* **Required**:  &#10003; Yes
+
+

--- a/test/test-golden/v2020-12-simple.md
+++ b/test/test-golden/v2020-12-simple.md
@@ -18,8 +18,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |**fraction**|`number`|A number that **MUST** be between zero and one.|No|
 |**moreFractions**|`number` `[3]`|An array of three fractional numbers.|No, default: `[0.1,0.2,0.3]`|
 
-Additional properties are allowed.
-
+* **Additional properties are not allowed.**
 ### Image.uri
 
 The URI (or IRI) of the image.  Relative paths are relative to the current glTF asset.  Instead of referencing an external file, this field **MAY** contain a `data:`-URI. This field **MUST NOT** be defined when `bufferView` is defined.

--- a/test/test-golden/v2020-12-simple.md
+++ b/test/test-golden/v2020-12-simple.md
@@ -17,6 +17,7 @@ Image data used to create a texture. Image **MAY** be referenced by an URI (or I
 |**bufferView**|`integer`|The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.|No|
 |**fraction**|`number`|A number that **MUST** be between zero and one.|No|
 |**moreFractions**|`number` `[3]`|An array of three fractional numbers.|No, default: `[0.1,0.2,0.3]`|
+|**metadata**|`object`||No|
 
 * **Additional properties are not allowed.**
 ### Image.uri
@@ -70,8 +71,53 @@ An array of three fractional numbers.
     * `[1.3, 4.03, 42]`
     * `[18, 0.1, 1.1]`
 
+### Image.metadata
+
+* **Type**: `object`
+* **Required**: No
+* **Additional properties are allowed.**
+* **Type of each property**: `meta`
+* **Property names**:
+    * **Pattern**: `^[A-Za-z_][A-Za-z0-9_]*$`
+    * **Minimum Length**`: >= 3`
+    * **Maximum Length**`: <= 10`
+    * **Allowed values**:
+        * `aperture`
+        * `camera`
+        * `lens`
+
+
 
 ## Examples
 
 * `{"uri": "https://raw.githubusercontent.com/KhronosGroup/glTF/main/specification/figures/gltf.png", "mimeType": "image/png"}`
 * `{"bufferView": 2, "fraction": 0.3, "moreFractions": [  1.1,  2.2,  3.3 ]}`
+
+
+
+
+---------------------------------------
+<a name="reference-meta"></a>
+## Metadatum
+
+A random piece of image metadata
+
+**`Metadatum` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**key**|`string`|| &#10003; Yes|
+|**val**|`string`|| &#10003; Yes|
+
+* **Additional properties are not allowed.**
+### meta.key
+
+* **Type**: `string`
+* **Required**:  &#10003; Yes
+
+### meta.val
+
+* **Type**: `string`
+* **Required**:  &#10003; Yes
+
+

--- a/test/test-schemas/v2020-12/image.schema.json
+++ b/test/test-schemas/v2020-12/image.schema.json
@@ -56,6 +56,17 @@
                 [1.3, 4.03, 42.0],
                 [18.0, 0.1, 1.1]
             ]
+        },
+        "metadata": {
+            "type": "object",
+            "title": "Metadata",
+            "additionalProperties": { "$ref": "meta.schema.json" },
+            "propertyNames": {
+                "enum": ["aperture", "camera", "lens"],
+                "minLength": 3,
+                "maxLength": 10,
+                "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+            }
         }
     },
     "dependencies": {


### PR DESCRIPTION
The new `getAdditionalProperties()` function, derived from behavior that was in `createPropertiesDetails()`, is now called at the top level to consistently show additional properties for the top-level schema as well as sub-properties. The behavior has been tweaked in a couple ways, however:

*   The `Additional properties are (not )? allowed` statements have been moved into bullet items, to match other property constraints. They also now always appear for every item.
*   The value for the `Type of each property` item is now the type specified by the `additionalProperties` object, rather than its parent. This seems clearly more correct to me, but it changed the output of tests for extensions, so that instead of listing the type as "Extension" it now says "object". There might be something funky going on with how composition of schemas affects things, but it's not clear to me what's going on here. So I left a comment showing the previous behavior, in case we need to go back to it.
*   The value of the `Type of each property` item can now be linked. It was supposed to be before but did not appear to work properly.

The handling of most of the basics of describing a schema have been moved into a new function, `getBasicSchemaInfo()`, so that it can be called recursively for `propertyNames`.

A new schema is added to the tests, referenced by an `additionalProperties` element in `test/test-schemas/v2020-12/image.schema.json` to demonstrate these changes. `image.schema.json` also includes a `propertyNames` element to ensure it works properly (even if its constraints don't make much sense). `propertyNames` was added in Draft 2019-09, not 2020-12, but this seemed like the simplest place to put it.

I suggest disabling whitespace changes in the diff view for a clearer view of the actual changes.