### PR TITLE
options to add more details in summary table / skip generation of detailed information

### DIFF
--- a/bin/wetzel.js
+++ b/bin/wetzel.js
@@ -26,7 +26,9 @@ if (!defined(argv._[0]) || defined(argv.h) || defined(argv.help)) {
         '  -d,  --debug              Provide a path, and this will save out intermediate processing\n' +
         '                                artifacts useful in debugging wetzel.\n' +
         '  -w,  --suppressWarnings   Will not print out WETZEL_WARNING strings indicating identified\n' +
-        '                                conversion problems. Default: false\n';
+        '                                conversion problems. Default: false\n' +
+        '  --describeEnums            List enum values in the description column of the summary table. Default: false\n' +
+        '  --summary                 Only write the summary and skip the detailed section, useful for a more concise documentation. Default: false\n'
     process.stdout.write(help);
     return;
 }
@@ -80,7 +82,9 @@ var options = {
     debug: defaultValue(defaultValue(argv.d, argv.debug), null),
     suppressWarnings: defaultValue(defaultValue(argv.w, argv.suppressWarnings), false),
     autoLink: autoLink,
-    ignorableTypes: ignorableTypes
+    ignorableTypes: ignorableTypes,
+    describeEnums: defaultValue(argv.describeEnums, false),
+    summaryOnly: defaultValue(argv.summary, false)
 };
 
 if (defined(embedOutput)) {

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -75,7 +75,9 @@ function generateMarkdown(options) {
             options.schemaRelativeBasePath,
             orderedTypesDescending,
             options.autoLink,
-            options.embedMode);
+            options.embedMode,
+            options.summaryOnly,
+            options.describeEnums);
     }
 
     return md;
@@ -154,7 +156,7 @@ function getRecursiveTOC(orderedTypes, parentTitle, depth) {
 * @param  {string} embedMode              Emum value indicating if we are embedding JSON schema include directives.
 * @return {string}                        The markdown for the schema.
 */
-function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, schemaRelativeBasePath, knownTypes, autoLink, embedMode) {
+function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, schemaRelativeBasePath, knownTypes, autoLink, embedMode, summaryOnly, describeEnums) {
     var md = '';
 
     if (schema === undefined) {
@@ -197,14 +199,17 @@ function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, sche
     // Render each property if the type is object
     if (schemaType === 'object') {
         // Render table with summary of each property
-        md += createPropertiesSummary(schema, knownTypes, autoLink);
+        md += createPropertiesSummary(schema, knownTypes, autoLink, describeEnums);
 
-        value = schema.additionalProperties;
-        if (defined(value) && !value) {
-            md += 'Additional properties are not allowed.\n\n';
-        } else {
-            md += 'Additional properties are allowed.\n\n';
-            // TODO: display their schema
+        if (!summaryOnly)
+        {
+            value = schema.additionalProperties;
+            if (defined(value) && !value) {
+                md += 'Additional properties are not allowed.\n\n';
+            } else {
+                md += 'Additional properties are allowed.\n\n';
+                // TODO: display their schema
+            }
         }
 
         // Schema reference
@@ -218,9 +223,12 @@ function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, sche
         }
 
         // Render section for each property
-        var title = defaultValue(schema.title, suppressWarnings ? '' : 'WETZEL_WARNING: title not defined');
-        md += createPropertiesDetails(schema, title, headerLevel + 1, knownTypes, autoLink);
-        md += createExamples(schema, headerLevel);
+        if (!summaryOnly)
+        {
+            var title = defaultValue(schema.title, suppressWarnings ? '' : 'WETZEL_WARNING: title not defined');
+            md += createPropertiesDetails(schema, title, headerLevel + 1, knownTypes, autoLink);
+            md += createExamples(schema, headerLevel);
+        }
     }
 
     return md;
@@ -228,7 +236,7 @@ function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, sche
 
 ////////////////////////////////////////////////////////////////////////////////
 
-function createPropertiesSummary(schema, knownTypes, autoLink) {
+function createPropertiesSummary(schema, knownTypes, autoLink, describeEnums) {
     var md = '';
 
     if (schema.properties !== undefined && Object.keys(schema.properties).length > 0) {
@@ -239,11 +247,25 @@ function createPropertiesSummary(schema, knownTypes, autoLink) {
             if (properties.hasOwnProperty(name)) {
                 var property = properties[name];
                 var summary = getPropertySummary(property, knownTypes, autoLink);
+                var description = defaultValue(summary.description, '')
+
+                if (describeEnums) {
+                    var enumString = getEnumString(property, summary.type, 1);
+                    if (defined(enumString)) {
+                        enumString = '**Allowed values** : ' + enumString.replace(/(?:\r\n|\r|\n|\*)/g, ' ');
+
+                        if (description != ''){
+                            description = description + "<br>"
+                        }
+
+                        description = description + enumString;
+                    }
+                }
 
                 md += style.addTableRow([
                     style.propertyNameSummary(name),
                     summary.formattedType,
-                    defaultValue(summary.description, ''),
+                    description,
                     (summary.required === 'Yes' ? style.requiredIcon : '') + summary.required
                 ]);
             }


### PR DESCRIPTION
This PR is proposing two new options:

- Skipping generation of detailed information, to have a much more concise output
- An option to add some additional information in the summary table directly, specifically the possible enum values

I hope it can be useful!
