### PR TITLE
A draft for supporting multiple search paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ There's also a version [published on npm](https://www.npmjs.com/package/wetzel).
 * The `-k` option replaces the word `must` with a specified keyword, such as `**MUST**`.
 * The `-p` option lets you specify the relative path that should be used when referencing the schema, relative to where you store the documentation.
 * The `-s` option lets you specify the path string that should be used when loading the schema reference paths.
+* The `-S` option lets you specify an array of path strings that should be used when loading the schema reference paths.
 * The `-e` option writes an additional output file that embeds the full text of JSON schemas (AsciiDoctor mode only).
 * The `-m` option controls the output style mode. The default is `Markdown`, use `-m=a` for `AsciiDoctor` mode.
 * The `-n` option will skip writing a Table of Contents.

--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -18,7 +18,7 @@ module.exports = generateMarkdown;
 function generateMarkdown(options) {
     var md = '';
     var schema = options.schema;
-    options.searchPath = defaultValue(options.searchPath, ['']);
+    options.searchPaths = defaultValue(options.searchPaths, ['']);
 
     var mode = enums.styleModeOption.Markdown;
     if (defined(options.styleMode) && options.styleMode === 'AsciiDoctor') {
@@ -39,10 +39,10 @@ function generateMarkdown(options) {
     var resolved = null;
     if (defined(schemaRef)) {
         if (schemaRef === 'http://json-schema.org/draft-03/schema') {
-            resolved = schema3.resolve(schema, options.fileName, options.searchPath, options.ignorableTypes, options.debug);
+            resolved = schema3.resolve(schema, options.fileName, options.searchPaths, options.ignorableTypes, options.debug);
         }
         else {
-            resolved = schema4.resolve(schema, options.fileName, options.searchPath, options.ignorableTypes, options.debug);
+            resolved = schema4.resolve(schema, options.fileName, options.searchPaths, options.ignorableTypes, options.debug);
             if ((!options.suppressWarnings) &&
                 (schemaRef !== 'http://json-schema.org/draft-04/schema' &&
                 schemaRef !== 'http://json-schema.org/draft-07/schema' &&

--- a/lib/schema3Resolver.js
+++ b/lib/schema3Resolver.js
@@ -14,13 +14,13 @@ module.exports = { resolve: resolve };
 * in the properties as-needed.
 * @param  {object} schema - The parsed json schema file as an object
 * @param  {string} fileName - The name of this schema file.
-* @param  {string[]} searchPath - The path list where any relative schema file references could be resolved
+* @param  {string[]} searchPaths - The path list where any relative schema file references could be resolved
 * @param  {string[]} ignorableTypes - An array of schema filenames that shouldn't get their own documentation section.
 * @param  {string} debugOutputPath [null] - If specified, intermediate processing artificats will be saved at this location for wetzel debugging purposes.
 * @return {object} The resolved schema object and its referenced schemas, as a map from the schema.title to objects
 * that contain the schema, the file name, the parents titles and the children titles
 */
-function resolve(schema, fileName, searchPath, ignorableTypes, debugOutputPath) {
+function resolve(schema, fileName, searchPaths, ignorableTypes, debugOutputPath) {
     // work off a cloned schema so that we're not modifying input objects
     var schemaClone = clone(schema, true);
     var referencedSchemas = {};
@@ -32,7 +32,7 @@ function resolve(schema, fileName, searchPath, ignorableTypes, debugOutputPath) 
     }
 
     referencedSchemas[schema.title] = { schema: schemaClone, fileName: fileName, parents: [], children: [] };
-    schemaClone = replaceRef(schemaClone, searchPath, ignorableTypes, referencedSchemas);
+    schemaClone = replaceRef(schemaClone, searchPaths, ignorableTypes, referencedSchemas);
     if (null !== debugOutputPath) {
         fs.writeFileSync(debugOutputPath + ".schema3.expanded.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }

--- a/lib/schema4Resolver.js
+++ b/lib/schema4Resolver.js
@@ -14,13 +14,13 @@ module.exports = { resolve: resolve };
 * in the properties as-needed.
 * @param  {object} schema - The parsed json schema file as an object
 * @param  {string} fileName - The name of this schema file.
-* @param  {string[]} searchPath - The path list where any relative schema file references could be resolved
+* @param  {string[]} searchPaths - The path list where any relative schema file references could be resolved
 * @param  {string[]} ignorableTypes - An array of schema filenames that shouldn't get their own documentation section.
 * @param  {string} debugOutputPath [null] - If specified, intermediate processing artificats will be saved at this location for wetzel debugging purposes.
 * @return {object} The resolved schema object and its referenced schemas, as a map from the schema.title to objects
 * that contain the schema, the file name, the parents titles and the children titles
 */
-function resolve(schema, fileName, searchPath, ignorableTypes, debugOutputPath) {
+function resolve(schema, fileName, searchPaths, ignorableTypes, debugOutputPath) {
     // work off a cloned schema so that we're not modifying input objects
     var schemaClone = clone(schema, true);
     var referencedSchemas = {};
@@ -32,7 +32,7 @@ function resolve(schema, fileName, searchPath, ignorableTypes, debugOutputPath) 
     }
 
     referencedSchemas[schema.title] = { schema: schemaClone, fileName: fileName, parents: [], children: [] };
-    schemaClone = replaceRef(schemaClone, searchPath, ignorableTypes, referencedSchemas);
+    schemaClone = replaceRef(schemaClone, searchPaths, ignorableTypes, referencedSchemas);
     if (null !== debugOutputPath) {
         fs.writeFileSync(debugOutputPath + ".schema4.expanded.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }

--- a/test/test-golden/multipleSearchPaths-embed.adoc
+++ b/test/test-golden/multipleSearchPaths-embed.adoc
@@ -1,0 +1,69 @@
+
+
+'''
+[#reference-multiplesearchpaths]
+== MultipleSearchPaths
+
+A schema that refers to schemas in different paths
+
+.`MultipleSearchPaths` Properties
+|===
+|   |Type|Description|Required
+
+|**examplePropertyA**
+|<<reference-searchpathsexternala,`searchPathsExternalA`>>
+|A schema that is referred to by another one
+|No
+
+|**examplePropertyB**
+|<<reference-searchpathsexternalb,`searchPathsExternalB`>>
+|A schema that is referred to by another one
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: <<schema-reference-multiplesearchpaths,`multipleSearchPaths.schema.json`>>
+
+=== MultipleSearchPaths.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: <<reference-searchpathsexternala,`searchPathsExternalA`>>
+* **Required**: No
+
+=== MultipleSearchPaths.examplePropertyB
+
+A schema that is referred to by another one
+
+* **Type**: <<reference-searchpathsexternalb,`searchPathsExternalB`>>
+* **Required**: No
+
+
+
+
+'''
+[#reference-searchpathsexternala]
+== SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+* **JSON schema**: <<schema-reference-searchpathsexternala,`searchPathsExternalA.schema.json`>>
+
+
+
+
+'''
+[#reference-searchpathsexternalb]
+== SearchPaths external B
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+* **JSON schema**: <<schema-reference-searchpathsexternalb,`searchPathsExternalB.schema.json`>>
+
+

--- a/test/test-golden/multipleSearchPaths-embedJSON.adoc
+++ b/test/test-golden/multipleSearchPaths-embedJSON.adoc
@@ -1,0 +1,33 @@
+
+
+[#schema-reference-multiplesearchpaths]
+== JSON Schema for MultipleSearchPaths
+
+[source,json]
+----
+include::schema/multipleSearchPaths.schema.json[]
+----
+
+<<<
+
+
+[#schema-reference-searchpathsexternala]
+== JSON Schema for SearchPaths external A
+
+[source,json]
+----
+include::schema/searchPathsExternalA.schema.json[]
+----
+
+<<<
+
+
+[#schema-reference-searchpathsexternalb]
+== JSON Schema for SearchPaths external B
+
+[source,json]
+----
+include::schema/searchPathsExternalB.schema.json[]
+----
+
+<<<

--- a/test/test-golden/multipleSearchPaths-keyword.md
+++ b/test/test-golden/multipleSearchPaths-keyword.md
@@ -1,0 +1,58 @@
+# Objects
+* [`MultipleSearchPaths`](#reference-multiplesearchpaths) (root object)
+* [`SearchPaths external A`](#reference-searchpathsexternala)
+* [`SearchPaths external B`](#reference-searchpathsexternalb)
+
+
+---------------------------------------
+<a name="reference-multiplesearchpaths"></a>
+## MultipleSearchPaths
+
+A schema that refers to schemas in different paths
+
+**`MultipleSearchPaths` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**examplePropertyA**|`searchPathsExternalA`|A schema that is referred to by another one|No|
+|**examplePropertyB**|`searchPathsExternalB`|A schema that is referred to by another one|No|
+
+Additional properties are allowed.
+
+### MultipleSearchPaths.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: `searchPathsExternalA`
+* **Required**: No
+
+### MultipleSearchPaths.examplePropertyB
+
+A schema that is referred to by another one
+
+* **Type**: `searchPathsExternalB`
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-searchpathsexternala"></a>
+## SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+
+
+
+---------------------------------------
+<a name="reference-searchpathsexternalb"></a>
+## SearchPaths external B
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+

--- a/test/test-golden/multipleSearchPaths-linked.adoc
+++ b/test/test-golden/multipleSearchPaths-linked.adoc
@@ -1,0 +1,73 @@
+== Objects
+* <<reference-multiplesearchpaths,`MultipleSearchPaths`>> (root object)
+* <<reference-searchpathsexternala,`SearchPaths external A`>>
+* <<reference-searchpathsexternalb,`SearchPaths external B`>>
+
+
+'''
+[#reference-multiplesearchpaths]
+=== MultipleSearchPaths
+
+A schema that refers to schemas in different paths
+
+.`MultipleSearchPaths` Properties
+|===
+|   |Type|Description|Required
+
+|**examplePropertyA**
+|<<reference-searchpathsexternala,`searchPathsExternalA`>>
+|A schema that is referred to by another one
+|No
+
+|**examplePropertyB**
+|<<reference-searchpathsexternalb,`searchPathsExternalB`>>
+|A schema that is referred to by another one
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/multipleSearchPaths.schema.json[multipleSearchPaths.schema.json]
+
+==== MultipleSearchPaths.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: <<reference-searchpathsexternala,`searchPathsExternalA`>>
+* **Required**: No
+
+==== MultipleSearchPaths.examplePropertyB
+
+A schema that is referred to by another one
+
+* **Type**: <<reference-searchpathsexternalb,`searchPathsExternalB`>>
+* **Required**: No
+
+
+
+
+'''
+[#reference-searchpathsexternala]
+=== SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/searchPathsExternalA.schema.json[searchPathsExternalA.schema.json]
+
+
+
+
+'''
+[#reference-searchpathsexternalb]
+=== SearchPaths external B
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/searchPathsExternalB.schema.json[searchPathsExternalB.schema.json]
+
+

--- a/test/test-golden/multipleSearchPaths-linked.md
+++ b/test/test-golden/multipleSearchPaths-linked.md
@@ -1,0 +1,64 @@
+## Objects
+* [`MultipleSearchPaths`](#reference-multiplesearchpaths) (root object)
+* [`SearchPaths external A`](#reference-searchpathsexternala)
+* [`SearchPaths external B`](#reference-searchpathsexternalb)
+
+
+---------------------------------------
+<a name="reference-multiplesearchpaths"></a>
+### MultipleSearchPaths
+
+A schema that refers to schemas in different paths
+
+**`MultipleSearchPaths` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**examplePropertyA**|[`searchPathsExternalA`](#reference-searchpathsexternala)|A schema that is referred to by another one|No|
+|**examplePropertyB**|[`searchPathsExternalB`](#reference-searchpathsexternalb)|A schema that is referred to by another one|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [multipleSearchPaths.schema.json](schema/multipleSearchPaths.schema.json)
+
+#### MultipleSearchPaths.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: [`searchPathsExternalA`](#reference-searchpathsexternala)
+* **Required**: No
+
+#### MultipleSearchPaths.examplePropertyB
+
+A schema that is referred to by another one
+
+* **Type**: [`searchPathsExternalB`](#reference-searchpathsexternalb)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-searchpathsexternala"></a>
+### SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+* **JSON schema**: [searchPathsExternalA.schema.json](schema/searchPathsExternalA.schema.json)
+
+
+
+
+---------------------------------------
+<a name="reference-searchpathsexternalb"></a>
+### SearchPaths external B
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+* **JSON schema**: [searchPathsExternalB.schema.json](schema/searchPathsExternalB.schema.json)
+
+

--- a/test/test-golden/multipleSearchPaths-remote.adoc
+++ b/test/test-golden/multipleSearchPaths-remote.adoc
@@ -1,0 +1,69 @@
+
+
+'''
+[#reference-multiplesearchpaths]
+== MultipleSearchPaths
+
+A schema that refers to schemas in different paths
+
+.`MultipleSearchPaths` Properties
+|===
+|   |Type|Description|Required
+
+|**examplePropertyA**
+|<<reference-searchpathsexternala,`searchPathsExternalA`>>
+|A schema that is referred to by another one
+|No
+
+|**examplePropertyB**
+|<<reference-searchpathsexternalb,`searchPathsExternalB`>>
+|A schema that is referred to by another one
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/multipleSearchPaths.schema.json[multipleSearchPaths.schema.json]
+
+=== MultipleSearchPaths.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: <<reference-searchpathsexternala,`searchPathsExternalA`>>
+* **Required**: No
+
+=== MultipleSearchPaths.examplePropertyB
+
+A schema that is referred to by another one
+
+* **Type**: <<reference-searchpathsexternalb,`searchPathsExternalB`>>
+* **Required**: No
+
+
+
+
+'''
+[#reference-searchpathsexternala]
+== SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+* **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/searchPathsExternalA.schema.json[searchPathsExternalA.schema.json]
+
+
+
+
+'''
+[#reference-searchpathsexternalb]
+== SearchPaths external B
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+* **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/searchPathsExternalB.schema.json[searchPathsExternalB.schema.json]
+
+

--- a/test/test-golden/multipleSearchPaths-remote.md
+++ b/test/test-golden/multipleSearchPaths-remote.md
@@ -1,0 +1,60 @@
+
+
+---------------------------------------
+<a name="reference-multiplesearchpaths"></a>
+## MultipleSearchPaths
+
+A schema that refers to schemas in different paths
+
+**`MultipleSearchPaths` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**examplePropertyA**|[`searchPathsExternalA`](#reference-searchpathsexternala)|A schema that is referred to by another one|No|
+|**examplePropertyB**|[`searchPathsExternalB`](#reference-searchpathsexternalb)|A schema that is referred to by another one|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [multipleSearchPaths.schema.json](https://www.khronos.org/wetzel/just/testing/schema/multipleSearchPaths.schema.json)
+
+### MultipleSearchPaths.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: [`searchPathsExternalA`](#reference-searchpathsexternala)
+* **Required**: No
+
+### MultipleSearchPaths.examplePropertyB
+
+A schema that is referred to by another one
+
+* **Type**: [`searchPathsExternalB`](#reference-searchpathsexternalb)
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-searchpathsexternala"></a>
+## SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+* **JSON schema**: [searchPathsExternalA.schema.json](https://www.khronos.org/wetzel/just/testing/schema/searchPathsExternalA.schema.json)
+
+
+
+
+---------------------------------------
+<a name="reference-searchpathsexternalb"></a>
+## SearchPaths external B
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+* **JSON schema**: [searchPathsExternalB.schema.json](https://www.khronos.org/wetzel/just/testing/schema/searchPathsExternalB.schema.json)
+
+

--- a/test/test-golden/multipleSearchPaths-simple.adoc
+++ b/test/test-golden/multipleSearchPaths-simple.adoc
@@ -1,0 +1,67 @@
+= Objects
+* <<reference-multiplesearchpaths,`MultipleSearchPaths`>> (root object)
+* <<reference-searchpathsexternala,`SearchPaths external A`>>
+* <<reference-searchpathsexternalb,`SearchPaths external B`>>
+
+
+'''
+[#reference-multiplesearchpaths]
+== MultipleSearchPaths
+
+A schema that refers to schemas in different paths
+
+.`MultipleSearchPaths` Properties
+|===
+|   |Type|Description|Required
+
+|**examplePropertyA**
+|`searchPathsExternalA`
+|A schema that is referred to by another one
+|No
+
+|**examplePropertyB**
+|`searchPathsExternalB`
+|A schema that is referred to by another one
+|No
+
+|===
+
+Additional properties are allowed.
+
+=== MultipleSearchPaths.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: `searchPathsExternalA`
+* **Required**: No
+
+=== MultipleSearchPaths.examplePropertyB
+
+A schema that is referred to by another one
+
+* **Type**: `searchPathsExternalB`
+* **Required**: No
+
+
+
+
+'''
+[#reference-searchpathsexternala]
+== SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+
+
+
+'''
+[#reference-searchpathsexternalb]
+== SearchPaths external B
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+

--- a/test/test-golden/multipleSearchPaths-simple.md
+++ b/test/test-golden/multipleSearchPaths-simple.md
@@ -1,0 +1,58 @@
+# Objects
+* [`MultipleSearchPaths`](#reference-multiplesearchpaths) (root object)
+* [`SearchPaths external A`](#reference-searchpathsexternala)
+* [`SearchPaths external B`](#reference-searchpathsexternalb)
+
+
+---------------------------------------
+<a name="reference-multiplesearchpaths"></a>
+## MultipleSearchPaths
+
+A schema that refers to schemas in different paths
+
+**`MultipleSearchPaths` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**examplePropertyA**|`searchPathsExternalA`|A schema that is referred to by another one|No|
+|**examplePropertyB**|`searchPathsExternalB`|A schema that is referred to by another one|No|
+
+Additional properties are allowed.
+
+### MultipleSearchPaths.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: `searchPathsExternalA`
+* **Required**: No
+
+### MultipleSearchPaths.examplePropertyB
+
+A schema that is referred to by another one
+
+* **Type**: `searchPathsExternalB`
+* **Required**: No
+
+
+
+
+---------------------------------------
+<a name="reference-searchpathsexternala"></a>
+## SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+
+
+
+---------------------------------------
+<a name="reference-searchpathsexternalb"></a>
+## SearchPaths external B
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+

--- a/test/test-golden/singleSearchPath-embed.adoc
+++ b/test/test-golden/singleSearchPath-embed.adoc
@@ -1,0 +1,44 @@
+
+
+'''
+[#reference-searchpathsexternala]
+== SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+* **JSON schema**: <<schema-reference-searchpathsexternala,`searchPathsExternalA.schema.json`>>
+
+
+
+
+'''
+[#reference-singlesearchpath]
+== SingleSearchPath
+
+A schema that refers to a schema in a different path
+
+.`SingleSearchPath` Properties
+|===
+|   |Type|Description|Required
+
+|**examplePropertyA**
+|<<reference-searchpathsexternala,`searchPathsExternalA`>>
+|A schema that is referred to by another one
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: <<schema-reference-singlesearchpath,`singleSearchPath.schema.json`>>
+
+=== SingleSearchPath.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: <<reference-searchpathsexternala,`searchPathsExternalA`>>
+* **Required**: No
+
+

--- a/test/test-golden/singleSearchPath-embedJSON.adoc
+++ b/test/test-golden/singleSearchPath-embedJSON.adoc
@@ -1,0 +1,22 @@
+
+
+[#schema-reference-searchpathsexternala]
+== JSON Schema for SearchPaths external A
+
+[source,json]
+----
+include::schema/searchPathsExternalA.schema.json[]
+----
+
+<<<
+
+
+[#schema-reference-singlesearchpath]
+== JSON Schema for SingleSearchPath
+
+[source,json]
+----
+include::schema/singleSearchPath.schema.json[]
+----
+
+<<<

--- a/test/test-golden/singleSearchPath-keyword.md
+++ b/test/test-golden/singleSearchPath-keyword.md
@@ -1,0 +1,38 @@
+# Objects
+* [`SearchPaths external A`](#reference-searchpathsexternala)
+* [`SingleSearchPath`](#reference-singlesearchpath) (root object)
+
+
+---------------------------------------
+<a name="reference-searchpathsexternala"></a>
+## SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+
+
+
+---------------------------------------
+<a name="reference-singlesearchpath"></a>
+## SingleSearchPath
+
+A schema that refers to a schema in a different path
+
+**`SingleSearchPath` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**examplePropertyA**|`searchPathsExternalA`|A schema that is referred to by another one|No|
+
+Additional properties are allowed.
+
+### SingleSearchPath.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: `searchPathsExternalA`
+* **Required**: No
+
+

--- a/test/test-golden/singleSearchPath-linked.adoc
+++ b/test/test-golden/singleSearchPath-linked.adoc
@@ -1,0 +1,47 @@
+== Objects
+* <<reference-searchpathsexternala,`SearchPaths external A`>>
+* <<reference-singlesearchpath,`SingleSearchPath`>> (root object)
+
+
+'''
+[#reference-searchpathsexternala]
+=== SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/searchPathsExternalA.schema.json[searchPathsExternalA.schema.json]
+
+
+
+
+'''
+[#reference-singlesearchpath]
+=== SingleSearchPath
+
+A schema that refers to a schema in a different path
+
+.`SingleSearchPath` Properties
+|===
+|   |Type|Description|Required
+
+|**examplePropertyA**
+|<<reference-searchpathsexternala,`searchPathsExternalA`>>
+|A schema that is referred to by another one
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:schema/singleSearchPath.schema.json[singleSearchPath.schema.json]
+
+==== SingleSearchPath.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: <<reference-searchpathsexternala,`searchPathsExternalA`>>
+* **Required**: No
+
+

--- a/test/test-golden/singleSearchPath-linked.md
+++ b/test/test-golden/singleSearchPath-linked.md
@@ -1,0 +1,42 @@
+## Objects
+* [`SearchPaths external A`](#reference-searchpathsexternala)
+* [`SingleSearchPath`](#reference-singlesearchpath) (root object)
+
+
+---------------------------------------
+<a name="reference-searchpathsexternala"></a>
+### SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+* **JSON schema**: [searchPathsExternalA.schema.json](schema/searchPathsExternalA.schema.json)
+
+
+
+
+---------------------------------------
+<a name="reference-singlesearchpath"></a>
+### SingleSearchPath
+
+A schema that refers to a schema in a different path
+
+**`SingleSearchPath` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**examplePropertyA**|[`searchPathsExternalA`](#reference-searchpathsexternala)|A schema that is referred to by another one|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [singleSearchPath.schema.json](schema/singleSearchPath.schema.json)
+
+#### SingleSearchPath.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: [`searchPathsExternalA`](#reference-searchpathsexternala)
+* **Required**: No
+
+

--- a/test/test-golden/singleSearchPath-remote.adoc
+++ b/test/test-golden/singleSearchPath-remote.adoc
@@ -1,0 +1,44 @@
+
+
+'''
+[#reference-searchpathsexternala]
+== SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+* **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/searchPathsExternalA.schema.json[searchPathsExternalA.schema.json]
+
+
+
+
+'''
+[#reference-singlesearchpath]
+== SingleSearchPath
+
+A schema that refers to a schema in a different path
+
+.`SingleSearchPath` Properties
+|===
+|   |Type|Description|Required
+
+|**examplePropertyA**
+|<<reference-searchpathsexternala,`searchPathsExternalA`>>
+|A schema that is referred to by another one
+|No
+
+|===
+
+Additional properties are allowed.
+
+* **JSON schema**: link:https://www.khronos.org/wetzel/just/testing/schema/singleSearchPath.schema.json[singleSearchPath.schema.json]
+
+=== SingleSearchPath.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: <<reference-searchpathsexternala,`searchPathsExternalA`>>
+* **Required**: No
+
+

--- a/test/test-golden/singleSearchPath-remote.md
+++ b/test/test-golden/singleSearchPath-remote.md
@@ -1,0 +1,39 @@
+
+
+---------------------------------------
+<a name="reference-searchpathsexternala"></a>
+## SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+* **JSON schema**: [searchPathsExternalA.schema.json](https://www.khronos.org/wetzel/just/testing/schema/searchPathsExternalA.schema.json)
+
+
+
+
+---------------------------------------
+<a name="reference-singlesearchpath"></a>
+## SingleSearchPath
+
+A schema that refers to a schema in a different path
+
+**`SingleSearchPath` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**examplePropertyA**|[`searchPathsExternalA`](#reference-searchpathsexternala)|A schema that is referred to by another one|No|
+
+Additional properties are allowed.
+
+* **JSON schema**: [singleSearchPath.schema.json](https://www.khronos.org/wetzel/just/testing/schema/singleSearchPath.schema.json)
+
+### SingleSearchPath.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: [`searchPathsExternalA`](#reference-searchpathsexternala)
+* **Required**: No
+
+

--- a/test/test-golden/singleSearchPath-simple.adoc
+++ b/test/test-golden/singleSearchPath-simple.adoc
@@ -1,0 +1,43 @@
+= Objects
+* <<reference-searchpathsexternala,`SearchPaths external A`>>
+* <<reference-singlesearchpath,`SingleSearchPath`>> (root object)
+
+
+'''
+[#reference-searchpathsexternala]
+== SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+
+
+
+'''
+[#reference-singlesearchpath]
+== SingleSearchPath
+
+A schema that refers to a schema in a different path
+
+.`SingleSearchPath` Properties
+|===
+|   |Type|Description|Required
+
+|**examplePropertyA**
+|`searchPathsExternalA`
+|A schema that is referred to by another one
+|No
+
+|===
+
+Additional properties are allowed.
+
+=== SingleSearchPath.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: `searchPathsExternalA`
+* **Required**: No
+
+

--- a/test/test-golden/singleSearchPath-simple.md
+++ b/test/test-golden/singleSearchPath-simple.md
@@ -1,0 +1,38 @@
+# Objects
+* [`SearchPaths external A`](#reference-searchpathsexternala)
+* [`SingleSearchPath`](#reference-singlesearchpath) (root object)
+
+
+---------------------------------------
+<a name="reference-searchpathsexternala"></a>
+## SearchPaths external A
+
+A schema that is referred to by another one
+
+Additional properties are allowed.
+
+
+
+
+---------------------------------------
+<a name="reference-singlesearchpath"></a>
+## SingleSearchPath
+
+A schema that refers to a schema in a different path
+
+**`SingleSearchPath` Properties**
+
+|   |Type|Description|Required|
+|---|---|---|---|
+|**examplePropertyA**|`searchPathsExternalA`|A schema that is referred to by another one|No|
+
+Additional properties are allowed.
+
+### SingleSearchPath.examplePropertyA
+
+A schema that is referred to by another one
+
+* **Type**: `searchPathsExternalA`
+* **Required**: No
+
+

--- a/test/test-schemas/index.json
+++ b/test/test-schemas/index.json
@@ -19,5 +19,13 @@
     }, {
         "name": "v2020-12",
         "path": "v2020-12/image.schema.json"
+    }, {
+        "name": "singleSearchPath",
+        "path": "searchPaths/singleSearchPath.schema.json",
+        "additionalOptions": "-s \"test/test-schemas/searchPaths/subdirectoryA\""
+    }, {
+        "name": "multipleSearchPaths",
+        "path": "searchPaths/multipleSearchPaths.schema.json",
+        "additionalOptions": "-S \"[ 'test/test-schemas/searchPaths/subdirectoryA', 'test/test-schemas/searchPaths/subdirectoryB' ]\""
     }]
 }

--- a/test/test-schemas/searchPaths/multipleSearchPaths.schema.json
+++ b/test/test-schemas/searchPaths/multipleSearchPaths.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "multipleSearchPaths.schema.json",
+  "title": "MultipleSearchPaths",
+  "type": "object",
+  "description": "A schema that refers to schemas in different paths",
+  "properties": {
+    "examplePropertyA": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "searchPathsExternalA.schema.json"
+        }
+      ]
+    },
+    "examplePropertyB": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "searchPathsExternalB.schema.json"
+        }
+      ]
+    }
+  }
+}

--- a/test/test-schemas/searchPaths/singleSearchPath.schema.json
+++ b/test/test-schemas/searchPaths/singleSearchPath.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "singleSearchPath.schema.json",
+  "title": "SingleSearchPath",
+  "type": "object",
+  "description": "A schema that refers to a schema in a different path",
+  "properties": {
+    "examplePropertyA": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "searchPathsExternalA.schema.json"
+        }
+      ]
+    }
+  }
+}

--- a/test/test-schemas/searchPaths/subdirectoryA/searchPathsExternalA.schema.json
+++ b/test/test-schemas/searchPaths/subdirectoryA/searchPathsExternalA.schema.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "searchPathsExternalA.schema.json",
+    "title": "SearchPaths external A",
+    "type": "object",
+    "description": "A schema that is referred to by another one"
+}

--- a/test/test-schemas/searchPaths/subdirectoryB/searchPathsExternalB.schema.json
+++ b/test/test-schemas/searchPaths/subdirectoryB/searchPathsExternalB.schema.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "searchPathsExternalA.schema.json",
+    "title": "SearchPaths external B",
+    "type": "object",
+    "description": "A schema that is referred to by another one"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -49,10 +49,10 @@ describe('wetzel', function () {
                     let embedOutputName = schema.name + '-' + (names[1] || '');
                     let embedOutputPathName = path.join(OUT_PREFIX, embedOutputName);
                     let embedGoldenPathName = path.join(GOLDEN_PREFIX, embedOutputName);
-
+                    let additionalOptions = schema.additionalOptions ? schema.additionalOptions : '';
                     it('should generate ' + outputName, function (done) {
                         const options = index.options[option].replace('{EMBED}', embedOutputPathName);
-                        const cmd = `${WETZEL_BIN} ${options} ${ignore} ${inputPathName} > ${outputPathName}`;
+                        const cmd = `${WETZEL_BIN} ${options} ${additionalOptions} ${ignore} ${inputPathName} > ${outputPathName}`;
                         exec(cmd, (error) => {
                             if (error) {
                                 console.error('** ERROR ** ' + error);


### PR DESCRIPTION
Currently, wetzel offers an option for additional search paths:

> - The `-s` option lets you specify the path string that should be used when loading the schema reference paths.

This could be extended in order to support _multiple_ search paths.

This PR is a **DRAFT**, for discussing whether (and how) this should be implemented. 

The change might raise questions:

- Is there backward compatibility on the command line level? 
  Callers might already use the `-s`/`-searchPath` parameter, and this should probably still work (for single paths) in the future. I introduced a `-S`/`-searchPaths` parameter (uppercase/plural), for the case that an _array_ of search paths should be given. Alternatively, the original `-s` parameter could be removed or replaced by the `-S` parameter, or it could try to _either_ accept a single string _or_ an array as the value for `-s`, or print a warning or error...
- Is there backward compatibility on the API level?
  The `options` object contained a `searchPath` field. This was passed to downstream functions with the name `seachPath`. But it actually already stored an _array_, and therefore, should be renamed to `searchPaths` (plural).
- Should this be covered with unit tests?
  The functionality of the `-s` parameter is not tested right now. Iff the functionality of the searchPath/searchPaths parameter should be tested, then it will be necessary to create a test schema, split into multiple directories. (It's not yet clear how well this could be covered with the current testing code...)


