### PR TITLE
Draft of adding descriptions for additionalProperties

### DIFF
--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -140,6 +140,41 @@ function getRecursiveTOC(orderedTypes, parentTitle, depth) {
     return md;
 }
 
+function createAdditionalPropertiesDescription(schema, fileName, headerLevel, suppressWarnings, schemaRelativeBasePath, knownTypes, autoLink, embedMode) {
+
+    const additionalProperties = schema.additionalProperties;
+
+    // If additionalProperties is defined but falsy, then no
+    // additional properties are allowed
+    if (defined(additionalProperties) && !additionalProperties) {
+        return 'Additional properties are not allowed.\n\n';
+    }
+
+    // If additionalProperties is defined and boolean 'true', then
+    // arbitrary additional properties are allowed
+    if (!defined(additionalProperties) || ((typeof additionalProperties === 'boolean') && additionalProperties)) {
+        return 'Additional properties are allowed.\n\n';
+    }
+
+    // If additionalProperties is a schema with a 'plain' type (i.e. not object), 
+    // just insert a statement with the type name
+    const additionalPropertiesType = getPropertyType(additionalProperties);
+    if (additionalPropertiesType !== 'object') {
+         return 'Additional properties are allowed, and must have type ' + style.typeValue(additionalPropertiesType) + '.\n\n';
+    }
+
+    // The additionalProperties are defined with a complex 
+    // schema. Add the full schema description.
+    let description = 'Additional properties are allowed, and must match the following schema:\n\n';
+    // Add a dummy title, if necessary, to prevent warnings...
+    if (!defined(additionalProperties.title)) {
+        additionalProperties.title = schema.title + '.additionalProperties';
+    }
+    description += getSchemaMarkdown(additionalProperties, fileName, headerLevel + 1, suppressWarnings, schemaRelativeBasePath, knownTypes, autoLink, embedMode);
+    return description;
+}
+
+
 /**
 * @function getSchemaMarkdown
 * Gets the markdown for the first-class elements of a schema.
@@ -199,13 +234,8 @@ function getSchemaMarkdown(schema, fileName, headerLevel, suppressWarnings, sche
         // Render table with summary of each property
         md += createPropertiesSummary(schema, knownTypes, autoLink);
 
-        value = schema.additionalProperties;
-        if (defined(value) && !value) {
-            md += 'Additional properties are not allowed.\n\n';
-        } else {
-            md += 'Additional properties are allowed.\n\n';
-            // TODO: display their schema
-        }
+        // Add the description for the additionalProperties
+        md += createAdditionalPropertiesDescription(schema, fileName, headerLevel, suppressWarnings, schemaRelativeBasePath, knownTypes, autoLink, embedMode);
 
         // Schema reference
         if (embedMode === enums.embedMode.referenceIncludeDocument) {


### PR DESCRIPTION
The `additionalProperties` property can either be a `boolean`, or a complete schema. 

Right now, the generator just checks whether this is defined and a falsy value, but there is a comment [`// TODO: display their schema`](https://github.com/CesiumGS/wetzel/blob/189f3f893e09dee3fb4f74edcf7fd4cbcb86bc8a/lib/generateMarkdown.js#L207) for the case that additional properties are allowed.

This is a **DRAFT** PR to talk about some options here.

This PR does not yet include test cases. Locally, I created some examples, for example
```
{
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "title" : "ExampleAdditionalPropertiesComplex",
    "description" : "An example with additionalProperties being a complex schema instead of a boolean value",
    "type" : "object",
    "properties": {
        "exampleProperty" : {
            "type" : "string"
        }
    },
    "additionalProperties": {
        "type": "object",
        "properties": {
            "exampleInteger": { "type": "number" },
            "exampleString": { "type": "string" },
            "exampleEnum": { "enum": ["ExampleEnumValueA", "ExampleEnumValueB"] }
          }
    }
}
```
which is converted into this (`...simple.md`) output:
```
# Objects
* [`ExampleAdditionalPropertiesComplex`](#reference-exampleadditionalpropertiescomplex) (root object)


---------------------------------------
<a name="reference-exampleadditionalpropertiescomplex"></a>
## ExampleAdditionalPropertiesComplex

An example with additionalProperties being a complex schema instead of a boolean value

**`ExampleAdditionalPropertiesComplex` Properties**

|   |Type|Description|Required|
|---|---|---|---|
|**exampleProperty**|`string`||No|

Additional properties are allowed, and must match the following schema:

---------------------------------------
<a name="reference-exampleadditionalpropertiescomplex-additionalproperties"></a>
### ExampleAdditionalPropertiesComplex.additionalProperties

**`ExampleAdditionalPropertiesComplex.additionalProperties` Properties**

|   |Type|Description|Required|
|---|---|---|---|
|**exampleInteger**|`number`||No|
|**exampleString**|`string`||No|
|**exampleEnum**|`any`||No|

Additional properties are allowed.

#### ExampleAdditionalPropertiesComplex.additionalProperties.exampleInteger

* **Type**: `number`
* **Required**: No

#### ExampleAdditionalPropertiesComplex.additionalProperties.exampleString

* **Type**: `string`
* **Required**: No

#### ExampleAdditionalPropertiesComplex.additionalProperties.exampleEnum

* **Type**: `any`
* **Required**: No
* **Allowed values**:
    * `ExampleEnumValueA`
    * `ExampleEnumValueB`


### ExampleAdditionalPropertiesComplex.exampleProperty

* **Type**: `string`
* **Required**: No
```

There certainly are some degrees of freedom for how exactly this should look like (and beyond that: in how far the final appearance should be _configurable_...). This includes the question in how far the final result should be linked. For example, there might be multiple schemas that allow additional properties to be `someVeryComplexThing`:
```
{
    ...
    "additionalProperties": {
        "type": "object",
        "allOf": [ { "$ref": "someVeryComplexThing.schema.json" } ]
    }
}
```
In these cases, the `someVeryComplexThing` should probably not be _inlined_, but created as a dedicated section.



