### PR TITLE
Refactoring replaceRef for definitions and circular references

### DIFF
--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -18,7 +18,7 @@ module.exports = generateMarkdown;
 function generateMarkdown(options) {
     var md = '';
     var schema = options.schema;
-    options.searchPath = defaultValue(options.searchPath, ['']);
+    options.searchPaths = defaultValue(options.searchPaths, ['']);
 
     var mode = enums.styleModeOption.Markdown;
     if (defined(options.styleMode) && options.styleMode === 'AsciiDoctor') {
@@ -39,10 +39,10 @@ function generateMarkdown(options) {
     var resolved = null;
     if (defined(schemaRef)) {
         if (schemaRef === 'http://json-schema.org/draft-03/schema') {
-            resolved = schema3.resolve(schema, options.fileName, options.searchPath, options.ignorableTypes, options.debug);
+            resolved = schema3.resolve(schema, options.fileName, options.searchPaths, options.ignorableTypes, options.debug);
         }
         else {
-            resolved = schema4.resolve(schema, options.fileName, options.searchPath, options.ignorableTypes, options.debug);
+            resolved = schema4.resolve(schema, options.fileName, options.searchPaths, options.ignorableTypes, options.debug);
             if ((!options.suppressWarnings) &&
                 (schemaRef !== 'http://json-schema.org/draft-04/schema' &&
                 schemaRef !== 'http://json-schema.org/draft-07/schema' &&

--- a/lib/replaceRef.js
+++ b/lib/replaceRef.js
@@ -8,52 +8,204 @@ var jsonpointer = require('jsonpointer');
 module.exports = replaceRef;
 
 /**
+ * Removes any fragment from the given URL (starting at `#`), if present.
+ * 
+ * @param {String} url The URL
+ * @returns The URL without fragment
+ */
+function stripFragment(url) {
+    if (!defined(url)) {
+        return undefined;
+    }
+    const hashIndex = url.indexOf('#');
+    if (hashIndex !== -1)
+    {
+        return url.substring(0, hashIndex);
+    }
+    return url;
+}
+
+/**
+ * Obtains the file name from a URL.
+ * 
+ * This will strip any fragment from the URL (starting at `#`), and
+ * return the part after the last slash `/` (or the full URL without
+ * the fragment if there is no slash) 
+ * 
+ * @param {String} url The URL
+ * @returns The file name
+ */
+function obtainFileName(url) {
+    if (!defined(url)) {
+        return undefined;
+    }
+    let result = stripFragment(url);
+    const slashIndex = result.indexOf('/');
+    if (slashIndex !== -1)  {
+        result = result.substring(slashIndex + 1);
+    }
+    return result;
+}
+
+/**
+ * Obtains the fragment from the given URL. 
+ * 
+ * This returns the part after the `#` (or the empty string,
+ * if there is no fragment)
+ * 
+ * @param {String} url The URL
+ * @returns The fragment
+ */
+function obtainFragment(url) {
+    if (!defined(url)) {
+        return undefined;
+    }
+    const hashIndex = url.indexOf('#');
+    if (hashIndex !== -1) {
+        return url.substring(hashIndex + 1);
+    }
+    return '';
+}
+
+/**
+ * Obtains the file name that the given reference refers to.
+ * 
+ * If the reference is absolute or contains a file name, then the file name
+ * is returned. Otherwise (if the reference is only a fragment containing
+ * a JSON pointer) then the given file name is returned.
+ *
+ * @param {String} ref The JSON schema reference
+ * @param {String} fileName The name of the file containing the JSON schema reference
+ * @returns The file that the reference should be resolved against.
+ */
+function obtainRefFileName(ref, fileName) {
+    if (path.isAbsolute(ref)) {
+        return obtainFileName(ref);
+    }
+    let refFileName = obtainFileName(ref);
+    if (refFileName.length === 0) {
+        refFileName = fileName;
+    }
+    return refFileName;
+}
+
+/**
+ * Resolves a JSON reference against the file that the reference refers to.
+ * 
+ * This will return an object containing `{ fileName, schema }`, where
+ * the `fileName` is the name of the file that the reference refers to,
+ * and `schema` will be the _whole_ schema from this file. 
+ * 
+ * (The actual part of the schema that the reference refers to can be 
+ * obtained using the fragment of the given reference string)
+ * 
+ * @param {String} ref The JSON schema reference
+ * @param {String} fileName The name of the file containing the JSON schema reference
+ * @param {String[]} searchPaths An array of paths that should be used for searching
+ * the referenced files
+ * @returns The result
+ */
+function resolveRefFile(ref, fileName, searchPaths) {   
+    if (path.isAbsolute(ref)) {
+        const fullRefFileName = stripFragment(ref);
+        const fullRefFileSchema = JSON.parse(fs.readFileSync(fullRefFileName));
+        const refFileName = obtainRefFileName(ref, fileName);
+        return {
+            fileName : refFileName,
+            schema : fullRefFileSchema,
+        };
+    } 
+    for (let searchPath of searchPaths) {
+        const refFileName = obtainRefFileName(ref, fileName);
+        try {
+            const fullRefFileName = path.join(searchPath, refFileName);
+            const fullRefFileSchema = JSON.parse(fs.readFileSync(fullRefFileName));
+            return {
+                fileName : refFileName,
+                schema : fullRefFileSchema,
+            };
+        } catch (ex) { 
+            // Keep searching in the searchPaths
+        }
+    }
+    const message = `Unable to resolve $ref ${ref}`;
+    //console.log(message);
+    throw new Error(message);
+}
+
+/**
+ * Resolve a JSON schema reference.
+ * 
+ * This will try to look up the given reference in the given schema repository.
+ * If this entry does not exist yet, if will resolve the file that the reference
+ * refers to, read its contents, and return an object containing `{ fileName, schema }`, 
+ * where the `fileName` is the name of the file that the reference refers to,
+ * and `schema` will be the actual part of schema that the reference refers to.
+ * 
+ * @param {String} ref The JSON schema reference
+ * @param {String} fileName The name of the file containing the JSON schema reference
+ * @param {String[]} searchPaths An array of paths that should be used for searching
+ * the referenced files
+ * @param {Object} schemaRepository A repository for the schemas
+ * @returns The result
+ */
+function resolveRef(ref, fileName, searchPaths, schemaRepository) {
+    if (defined(schemaRepository[ref])) {
+        return schemaRepository[ref];
+    }
+    const refFileName = obtainRefFileName(ref, fileName);
+    const fragment = obtainFragment(ref);
+
+    let fullRefFileEntry = schemaRepository[refFileName];
+    if (!defined(fullRefFileEntry)) {
+        fullRefFileEntry = resolveRefFile(ref, fileName, searchPaths);
+        schemaRepository[refFileName] = fullRefFileEntry;
+    }
+    const fullRefFileSchema = fullRefFileEntry.schema;
+    const refSchema = jsonpointer.get(fullRefFileSchema, fragment);
+    const refEntry = {
+        fileName : refFileName,
+        schema : refSchema
+    };
+    schemaRepository[ref] = refEntry;
+    return refEntry;
+}
+
+/**
 * @function replaceRef
 * Replaces json schema file references referenced with a $ref property
 * with the actual file content from the referenced schema file.
-* @todo Does not currently support absolute reference paths, only relative paths.
 * @param  {object} schema - The parsed json schema file as an object
+* @param  {string} fileName - The name of the parsed JSON schema file
 * @param  {string[]} searchPaths - The path list where any relative schema file references could be resolved
 * @param  {string[]} ignorableTypes - An array of schema filenames that shouldn't get their own documentation section.
 * @param  {object} schemaReferences - An object that will be populated with all schemas referenced by this object
+* @param  {object} schemaRepository - An object that will be populated with all referenced schemas
 * @param  {string} parentTitle - A string that contains the title of the parent object
 * @param  {object} root - The root schema
 * @return {object} The schema object with all schema file referenced replaced with the actual file content.
 */
-function replaceRef(schema, searchPaths, ignorableTypes, schemaReferences, parentTitle, root) {
+function replaceRef(schema, fileName, searchPaths, ignorableTypes, schemaReferences, schemaRepository, parentTitle, root) {
+
     if (!root) {
         root = schema;
     }
 
     schemaReferences = defaultValue(schemaReferences, {});
 
-    var ref = schema.$ref;
-    if (defined(ref)) {
-        // TODO: $ref could also be absolute.
-        var refSchema, fileName;
-        for (var searchPath of searchPaths) {
-            try {
-                var [file, pointer] = ref.split(/#(.*)/);
-                if (file) {
-                    var filePath = path.join(searchPath, file);
-                    refSchema = JSON.parse(fs.readFileSync(filePath));
-                    fileName = file;
-                } else {
-                    refSchema = root;
-                    fileName = '';
-                }
-                if (pointer) {
-                    refSchema = jsonpointer.get(refSchema, pointer);
-                    refSchema.typeName = pointer.split('/').pop();
-                }
-                break;
-            } catch (ex) { refSchema = undefined; }
-        }
+    const ref = schema.$ref;
+    if (defined(ref) && !defined(schemaRepository[ref])) {
+
+        const resolveRefResult = resolveRef(ref, fileName, searchPaths, schemaRepository);
+
+        //console.log(`Resolved $ref ${ref}`, resolveRefResult);
+
+        const refFileName = resolveRefResult.fileName;
+        const refSchema = resolveRefResult.schema;
 
         if (!defined(refSchema)) {
             throw new Error(`Unable to find $ref ${ref}`);
         }
-
         if (!defined(refSchema.title)) {
             throw new Error(`No title found in $ref ${ref}`);
         }
@@ -63,13 +215,13 @@ function replaceRef(schema, searchPaths, ignorableTypes, schemaReferences, paren
         // (meaning it would never show up in a table of contents or get its own documentation section).
         if (ignorableTypes.indexOf(ref.toLowerCase()) < 0) {
             if (refSchema.title in schemaReferences) {
-                // update schema and fileName in case it was inserted by a child first
+                // update schema and refFileName in case it was inserted by a child first
                 schemaReferences[refSchema.title].schema = refSchema;
-                schemaReferences[refSchema.title].fileName = fileName;
+                schemaReferences[refSchema.title].fileName = refFileName;
                 schemaReferences[refSchema.title].parents.push(parentTitle);
             }
             else {
-                schemaReferences[refSchema.title] = { schema: refSchema, fileName, parents: [parentTitle], children: [] };
+                schemaReferences[refSchema.title] = { schema: refSchema, fileName: refFileName, parents: [parentTitle], children: [] };
             }
 
             if (parentTitle in schemaReferences) {
@@ -82,22 +234,26 @@ function replaceRef(schema, searchPaths, ignorableTypes, schemaReferences, paren
             // From a reference named "simpleExample.type.schema.json",
             // extract the "simpleExample.type" part as the type name
             if (!refSchema.typeName) {
-                var typeName = fileName;
-                var indexOfFileExtension = fileName.indexOf(".schema.json");
+                var typeName = refFileName;
+                var indexOfFileExtension = refFileName.indexOf(".schema.json");
                 if (indexOfFileExtension !== -1) {
-                    typeName = fileName.slice(0, indexOfFileExtension);
+                    typeName = refFileName.slice(0, indexOfFileExtension);
+                }
+                const fragment = obtainFragment(ref);
+                if (fragment.length != 0) {
+                    typeName += fragment;
                 }
                 refSchema.typeName = typeName;
             }
         }
 
-        return replaceRef(refSchema, searchPaths, ignorableTypes, schemaReferences, schema.title === undefined ? parentTitle : schema.title, root);
+        return replaceRef(refSchema, refFileName, searchPaths, ignorableTypes, schemaReferences, schemaRepository, schema.title === undefined ? parentTitle : schema.title, root);
     }
 
     for (var name in schema) {
         if (schema.hasOwnProperty(name)) {
             if (typeof schema[name] === 'object') {
-                schema[name] = replaceRef(schema[name], searchPaths, ignorableTypes, schemaReferences, schema.title === undefined ? parentTitle : schema.title, root);
+                schema[name] = replaceRef(schema[name], fileName, searchPaths, ignorableTypes, schemaReferences, schemaRepository, schema.title === undefined ? parentTitle : schema.title, root);
             }
         }
     }

--- a/lib/schema3Resolver.js
+++ b/lib/schema3Resolver.js
@@ -32,7 +32,8 @@ function resolve(schema, fileName, searchPaths, ignorableTypes, debugOutputPath)
     }
 
     referencedSchemas[schema.title] = { schema: schemaClone, fileName: fileName, parents: [], children: [] };
-    schemaClone = replaceRef(schemaClone, searchPaths, ignorableTypes, referencedSchemas);
+    const schemaRepository = {};
+    schemaClone = replaceRef(schemaClone, fileName, searchPaths, ignorableTypes, referencedSchemas, schemaRepository);
     if (null !== debugOutputPath) {
         fs.writeFileSync(debugOutputPath + ".schema3.expanded.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }

--- a/lib/schema3Resolver.js
+++ b/lib/schema3Resolver.js
@@ -14,13 +14,13 @@ module.exports = { resolve: resolve };
 * in the properties as-needed.
 * @param  {object} schema - The parsed json schema file as an object
 * @param  {string} fileName - The name of this schema file.
-* @param  {string[]} searchPath - The path list where any relative schema file references could be resolved
+* @param  {string[]} searchPaths - The path list where any relative schema file references could be resolved
 * @param  {string[]} ignorableTypes - An array of schema filenames that shouldn't get their own documentation section.
 * @param  {string} debugOutputPath [null] - If specified, intermediate processing artificats will be saved at this location for wetzel debugging purposes.
 * @return {object} The resolved schema object and its referenced schemas, as a map from the schema.title to objects
 * that contain the schema, the file name, the parents titles and the children titles
 */
-function resolve(schema, fileName, searchPath, ignorableTypes, debugOutputPath) {
+function resolve(schema, fileName, searchPaths, ignorableTypes, debugOutputPath) {
     // work off a cloned schema so that we're not modifying input objects
     var schemaClone = clone(schema, true);
     var referencedSchemas = {};
@@ -32,7 +32,7 @@ function resolve(schema, fileName, searchPath, ignorableTypes, debugOutputPath) 
     }
 
     referencedSchemas[schema.title] = { schema: schemaClone, fileName: fileName, parents: [], children: [] };
-    schemaClone = replaceRef(schemaClone, searchPath, ignorableTypes, referencedSchemas);
+    schemaClone = replaceRef(schemaClone, searchPaths, ignorableTypes, referencedSchemas);
     if (null !== debugOutputPath) {
         fs.writeFileSync(debugOutputPath + ".schema3.expanded.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }

--- a/lib/schema4Resolver.js
+++ b/lib/schema4Resolver.js
@@ -14,13 +14,13 @@ module.exports = { resolve: resolve };
 * in the properties as-needed.
 * @param  {object} schema - The parsed json schema file as an object
 * @param  {string} fileName - The name of this schema file.
-* @param  {string[]} searchPath - The path list where any relative schema file references could be resolved
+* @param  {string[]} searchPaths - The path list where any relative schema file references could be resolved
 * @param  {string[]} ignorableTypes - An array of schema filenames that shouldn't get their own documentation section.
 * @param  {string} debugOutputPath [null] - If specified, intermediate processing artificats will be saved at this location for wetzel debugging purposes.
 * @return {object} The resolved schema object and its referenced schemas, as a map from the schema.title to objects
 * that contain the schema, the file name, the parents titles and the children titles
 */
-function resolve(schema, fileName, searchPath, ignorableTypes, debugOutputPath) {
+function resolve(schema, fileName, searchPaths, ignorableTypes, debugOutputPath) {
     // work off a cloned schema so that we're not modifying input objects
     var schemaClone = clone(schema, true);
     var referencedSchemas = {};
@@ -32,7 +32,7 @@ function resolve(schema, fileName, searchPath, ignorableTypes, debugOutputPath) 
     }
 
     referencedSchemas[schema.title] = { schema: schemaClone, fileName: fileName, parents: [], children: [] };
-    schemaClone = replaceRef(schemaClone, searchPath, ignorableTypes, referencedSchemas);
+    schemaClone = replaceRef(schemaClone, searchPaths, ignorableTypes, referencedSchemas);
     if (null !== debugOutputPath) {
         fs.writeFileSync(debugOutputPath + ".schema4.expanded.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }

--- a/lib/schema4Resolver.js
+++ b/lib/schema4Resolver.js
@@ -32,7 +32,8 @@ function resolve(schema, fileName, searchPaths, ignorableTypes, debugOutputPath)
     }
 
     referencedSchemas[schema.title] = { schema: schemaClone, fileName: fileName, parents: [], children: [] };
-    schemaClone = replaceRef(schemaClone, searchPaths, ignorableTypes, referencedSchemas);
+    const schemaRepository = {};
+    schemaClone = replaceRef(schemaClone, fileName, searchPaths, ignorableTypes, referencedSchemas, schemaRepository);
     if (null !== debugOutputPath) {
         fs.writeFileSync(debugOutputPath + ".schema4.expanded.json", JSON.stringify(schemaClone), function (err) {
             if (err) { console.log(err); }

--- a/lib/style.js
+++ b/lib/style.js
@@ -412,7 +412,8 @@ function styleCodeType(string, type) {
 function createAnchorName(string) {
     return string.toLowerCase()
         .replace(/ /g, "-")
-        .replace(/\./g, "-");
+        .replace(/\./g, "-")
+        .replace(/\//g, "-");
 }
 
 /**

--- a/test/test-schemas/circular/circular.schema.json
+++ b/test/test-schemas/circular/circular.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Circular references",
+  "description": "An example schema with circular references",
+  "type": "object",
+  "definitions": {
+    "node": {
+      "title": "A node, either a leaf node or an inner node",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/leafNode"
+        },
+        {
+          "$ref": "#/definitions/innerNode"
+        }
+      ]
+    },
+    "leafNode": {
+      "title": "A leaf node",
+      "type": "object"
+    },
+    "innerNode": {
+      "title": "An inner node with children",
+      "type": "object",
+      "properties": {
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/node"
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+    "root": {
+      "allOf": [{ "$ref": "#/definitions/node" }]
+    }
+  }
+}

--- a/test/test-schemas/definitions/definitions.schema.json
+++ b/test/test-schemas/definitions/definitions.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Definitions example",
+  "description": "An example with definitions",
+  "type": "object",
+  "definitions": {
+    "exampleDefinition": {
+      "title": "An example definition",
+      "type": "string"
+    },
+    "exampleReferenceDefinition": {
+      "title": "An example definition that refers to another one",
+      "allOf": [
+        {
+          "$ref": "#/definitions/exampleDefinition"
+        }
+      ]
+    }
+  }
+}

--- a/test/test-schemas/definitions/definitionsUser.schema.json
+++ b/test/test-schemas/definitions/definitionsUser.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Definitions user example",
+  "description": "An example that uses definitions from another file",
+  "type": "object",
+  "properties": {
+    "exampleProperty": {
+      "allOf": [
+        {
+          "$ref": "definitions.schema.json#/definitions/exampleReferenceDefinition"
+        }
+      ]
+    }
+  }
+}

--- a/test/test-schemas/index.json
+++ b/test/test-schemas/index.json
@@ -13,6 +13,12 @@
         "name": "example",
         "path": "example/example.schema.json"
     }, {
+        "name": "definitions",
+        "path": "definitions/definitions.schema.json"
+    }, {
+        "name": "circular",
+        "path": "circular/circular.schema.json"
+    },{
         "name": "nested",
         "path": "nested/nestedTest.schema.json",
         "ignore": "['nestedid.schema.json', 'nestedchildofrootproperty.schema.json', 'nestedtestproperty.schema.json']"


### PR DESCRIPTION
This is a **DRAFT** for a somewhat broader refactoring of the `replaceRef` function. (It is based on the state from https://github.com/CesiumGS/wetzel/pull/71, but that could easily be separated). 

The [current `replaceRef` function](https://github.com/CesiumGS/wetzel/blob/189f3f893e09dee3fb4f74edcf7fd4cbcb86bc8a/lib/replaceRef.js#L23) has some issues:

- https://github.com/CesiumGS/wetzel/issues/73
- https://github.com/CesiumGS/wetzel/issues/56
- From the code: `// TODO: $ref could also be absolute.`

The changes in this PR are supposed to address these issues. The implementation now tries to keep track of the replacements that have been done, mainly by storing the references in a "schemaRepository", and to properly substitute definitions even when they are across multiple files.

I added some _basic_ test cases for the new functionality. But further tests will have be be done to verify that other changes in the output, compared to the "golden" state that is checked in, are not just "changes", but actually _improvements_.

The prominent role of `schema.title` for _identifying_ a schema makes it difficult to track the state that the output is generated from. The role of the (undocumented) `schema.typeName` is something that I'll still have to wrap my head around. (And although I'm a bit curious to see how things would collapse when an input schema contained a property called `typeName`, that's probably something that may not be considered to be important in the near future...)


