### PR TITLE
Refactoring for the style

### DIFF
--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -4,10 +4,13 @@ var defaultValue = require('./defaultValue');
 var sortObject = require('./sortObject');
 var schema3 = require('./schema3Resolver');
 var schema4 = require('./schema4Resolver');
-var style = require('./style');
+var styleMd = require('./styleMd');
+var styleAdoc = require('./styleAdoc');
 var enums = require('./enums');
 
 module.exports = generateMarkdown;
+
+let style;
 
 /**
 * @function generateMarkdown
@@ -20,11 +23,10 @@ function generateMarkdown(options) {
     var schema = options.schema;
     options.searchPath = defaultValue(options.searchPath, ['']);
 
-    var mode = enums.styleModeOption.Markdown;
+    style = new styleMd();
     if (defined(options.styleMode) && options.styleMode === 'AsciiDoctor') {
-        mode = enums.styleModeOption.AsciiDoctor;
+        style = new styleAdoc();
     }
-    style.setStyleMode(mode);
 
     if (defined(options.checkmark)) {
         style.setCheckmark(options.checkmark);

--- a/lib/style.js
+++ b/lib/style.js
@@ -3,126 +3,18 @@ var defined = require('./defined');
 var defaultValue = require('./defaultValue');
 var enums = require('./enums');
 
-var moduleStyleMode = enums.styleModeOption.Markdown;
-
-module.exports = {
-    setStyleMode: setStyleMode,
-
-    setCheckmark: setCheckmark,
-
-    setMustKeyword: setMustKeyword,
-
-    getHeaderMarkdown: getHeaderMarkdown,
-
-    getSectionMarkdown: getSectionMarkdown,
-
-    getLinkMarkdown: getLinkMarkdown,
-
-    bulletItem: bulletItem,
-
-    beginTable: beginTable,
-
-    addTableRow: addTableRow,
-
-    endTable: endTable,
+/* eslint-disable no-unused-vars */
+const Style = {
 
     /**
-    * @function bold
-    * Bold the specified string
-    * @param  {string} string - The string to be styled
-    * @return {string} The string styled as bolded for display in markdown.
+    * @property {string} anchorPrefix - The prefix that will be used for internal anchors
     */
-    bold: styleBold,
+    anchorPrefix: 'reference-',
 
     /**
-    * @function type
-    * Format the type heading for display in markdown
-    * @param  {string} string - The type heading to be styled
-    * @return {string} The type heading styled for display in markdown.
+    * @property {string} anchorSchemaPrefix - The prefix that will be used for internal anchors of embedded JSON schema
     */
-    type: styleBold,
-
-    /**
-    * @function typeValue
-    * Format a typeValue for display in markdown
-    * @param  {string} string - The type value to be styled
-    * @return {string} The typeValue styled for display in markdown.
-    */
-    typeValue: styleCode,
-
-    /**
-    * @function propertiesSummary
-    * Format the summary of properties for display in markdown
-    * @param  {string} string - The summary of properties to be styled
-    * @return {string} The summary of properties styled for display in markdown.
-    */
-    propertiesSummary: styleBold,
-
-    /**
-    * @function propertyNameSummary
-    * Format a property name for display in markdown
-    * @param  {string} string - The property name summary to be styled
-    * @return {string} The styled property name summary for display in markdown.
-    */
-    propertyNameSummary: styleBold,
-
-    /**
-    * @function propertiesDetails
-    * Format the details of properties for display in markdown
-    * @param  {string} string - The details of properties to be styled
-    * @return {string} The details of properties styled for display in markdown.
-    */
-    propertiesDetails: styleBold,
-
-    /**
-    * @function propertyDetails
-    * Format the details of a property for display in markdown
-    * @param  {string} string - The property details to be styled
-    * @return {string} The property details styled for display in markdown.
-    */
-    propertyDetails: styleBold,
-
-    /**
-    * @function propertyGltfWebGL
-    * Format a glTF WebGL property for display in markdown
-    * @param  {string} string - The glTF WebGL property to be styled
-    * @return {string} The glTF WebGL property styled for display in markdown.
-    */
-    propertyGltfWebGL: styleBold,
-
-    /**
-    * @function defaultValue
-    * Format a defaultValue for display in markdown
-    * @param  {string} string - The default value
-    * @param  {type} string - The type of the default value
-    * @return {string} The default value styled for display in markdown.
-    */
-    defaultValue: styleCodeType,
-
-    /**
-    * @function enumElement
-    * Format an enumElement for display in markdown
-    * @param  {string} string - The enum element to be styled
-    * @param  {type} string - The type of the enum element
-    * @return {string} The enum element styled for display in markdown.
-    */
-    enumElement: styleCodeType,
-
-    /**
-    * @function minMax
-    * Format a minimum or maximum value for display in markdown
-    * @param  {int} value - The minimum/maximum value to be styled
-    * @return {string} The minimum or maximum value styled for display in markdown.
-    */
-    minMax: styleMinMax,
-
-    linkType: linkType,
-
-    getTOCLink: getTOCLink,
-
-    getSchemaEmbedLink: getSchemaEmbedLink,
-
-    embedJsonSchema: embedJsonSchema,
+    anchorSchemaPrefix: 'schema-reference-',
 
     /**
     * @property {string} requiredIcon - The markdown string used for displaying the icon used to indicate a value is required.
@@ -133,373 +25,351 @@ module.exports = {
      * @property {string} mustKeyword - The keyword used when a condition must be true.
      */
     mustKeyword: ' must ',
+
+    /**
+     * @function setCheckmark
+     * Set the symbol used to indicate required properties.
+     * @param {string} checkmark The desired symbol
+     */
+    setCheckmark : function(checkmark) {
+        if (checkmark.length > 0) {
+            this.requiredIcon = ' ' + checkmark + ' ';
+        } else {
+            this.requiredIcon = '';
+        }
+    },
+
+    /**
+     * @function setMustKeyword
+     * Set the keyword used in place of the word "must".
+     * @param {string} mustKeyword The keyword used when a condition must be true.
+     */
+    setMustKeyword : function(mustKeyword) {
+        if (mustKeyword.length > 0) {
+            this.mustKeyword = ' ' + mustKeyword + ' ';
+        } else {
+            this.mustKeyword = ' must ';
+        }
+    },
+
+    /**
+    * @function getHeaderMarkdown
+    * Gets the markdown syntax for the start of a header.
+    * @param  {int} level - The header lever that is being requested
+    * @return {string} The markdown string that should be placed prior to the title of the header
+    */
+    getHeaderMarkdown: function(level) {
+        throw new Error("Should be implemented by subclasses");
+    },
+
+    /**
+    * @function getSectionMarkdown
+    * Gets the markdown syntax for the start of a section.
+    * @param  {object} schema - The schema for which this section is created
+    * @param  {int} level - The header lever that is being requested
+    * @param  {boolean} suppressWarnings Indicates if wetzel warnings should be printed in the documentation.
+    * @param  {string} embedMode Emum value indicating if we are embedding JSON schema include directives.
+    * @return {string} The markdown string that should be placed as the start of the section
+    */
+    getSectionMarkdown : function(schema, level, suppressWarnings, embedMode) {
+        throw new Error("Should be implemented by subclasses");
+    },
+
+    /**
+    * @function getSectionMarkdown
+    * Gets the markdown syntax for a bulleted item.
+    * @param  {string} item - The item being bulleted.
+    * @param  {int} indentationLevel - The number of indentation levels that should be applied
+    * @return {string} The markdown string representing the item as a bulleted item at the proper indentation.
+    */
+    bulletItem: function(item, indentationLevel) {
+        throw new Error("Should be implemented by subclasses");
+    },
+
+    /**
+    * @function getLinkMarkdown
+    * Creates a markdown link
+    * @param  {string} string - The string to be linked
+    * @param  {string} link - The link that should be applied to the string
+    * @return {string} The markdown with the specified string hyperlinked to the specified link.
+    */
+    getLinkMarkdown: function(string, link) {
+        throw new Error("Should be implemented by subclasses");
+    },
+
+    /**
+     * Creates a table header
+     * @param {string} title - The name of this table
+     * @param {array} columnList - An array of column names
+     */
+    beginTable: function(title, columnList) {
+        throw new Error("Should be implemented by subclasses");
+    },
+
+    /**
+     * Adds a row of cells to a table
+     * @param {array} data - An array of data for cells on this row.
+     */
+    addTableRow: function(data) {
+        throw new Error("Should be implemented by subclasses");
+    }, 
+
+    /**
+     * Ends a table.
+     */
+    endTable: function() {
+        throw new Error("Should be implemented by subclasses");
+    },
+
+    /**
+    * @function styleBold
+    * Returns back a markdown string that bolds the provided string.
+    * @param  {string} string - The string to be bolded
+    * @return {string} The bolded string in markdown syntax
+    */
+    styleBold: function(string) {
+        if (defined(string) && string.length > 0) {
+            return '**' + string + '**';
+        }
+
+        return '';
+    },
+
+    /**
+    * @function styleCode
+    * Returns back a markdown string that displays the provided object as code.
+    * @param  {object} code - The object to be displayed as code. It might be a string, or a number, or ...
+    * @return {string} The code in markdown code syntax
+    */
+    styleCode: function(code) {
+        if (defined(code)) {
+            // If it's an object, just serialize it.
+            if (typeof code === 'object') {
+                // Someday may want to use a code fence if it's longer than, say, 88
+                // chars, but that would require keeping track of the current
+                // indentation. Not really how things are designed to work right
+                // now. So add spaces but let it display as a single line for now.
+                return '`' + JSON.stringify(code, null, 1).replace(/\n/g, '').replace(/([{[]) /, '$1') + '`';
+            }
+
+            // The object might be a string or it might be a number or something else.
+            // Let's make sure it's a string first.
+            var stringified = code.toString();
+
+            if (stringified.length > 0) {
+                return '`' + stringified + '`';
+            }
+        }
+
+        return '';
+    },
+
+    /**
+    * @function styleMinMax
+    * Returns back a markdown string that displays the provided min/max values as code.
+    * @param  {object} code - The object to be displayed as min/max code. It might be a string, or a number, or ...
+    * @return {string} The code in markdown code syntax
+    */
+    styleMinMax: function(code) {
+        throw new Error("Should be implemented by subclasses");
+    },
+
+    /**
+    * @function styleCodeType
+    * Returns back a markdown string that displays the provided string as code.
+    * @param  {string} string - The string to be displayed as code
+    * @param  {string} type - The type of the content in string (if it's a literal string, it will be formatted differently)
+    * @return {string} The string in markdown code syntax
+    */
+    styleCodeType: function(string, type) {
+        if (!defined(string) || string.length === 0) {
+            return '';
+        } else if (type === 'string') {
+            return this.styleCode('"' + string + '"');
+        }
+
+        return this.styleCode(string);
+    },
+
+    /**
+     * Convert the given string into the string that will be used for
+     * the anchors that serve as link targets in the resulting MD.
+     *
+     * @param {string} string The string
+     * @return {string} The anchor name
+     */
+    createAnchorName: function(string) {
+        return string.toLowerCase()
+            .replace(/ /g, "-")
+            .replace(/\./g, "-");
+    },
+
+    /**
+    * @function linkType
+    * Finds any occurrence of type in the provided string, and adds a markdown link to it.
+    * @param  {string} string - The string that might be referencing a type
+    * @param  {string} type - The type whose reference within string should be linked.
+    * @param  {string} autoLink - The enum value indicating how the auto-linking should be handled.
+    * @return {string} The updated string, with any occurrences of the @type string linked via markdown.
+    */
+    linkType: function(string, type, autoLink) {
+        if (defaultValue(autoLink, enums.autoLinkOption.off) === enums.autoLinkOption.off) {
+            return string;
+        } else if ((!defined(string) || string.length === 0)) {
+            return string;
+        } else if ((!defined(type) || type.length === 0)) {
+            return string;
+        }
+        if (type === 'integer' || type === 'string' ||
+            type === 'object'  || type === 'number' ||
+            type === 'boolean') {
+            return string;
+        }
+        var typeLink = '#' + this.anchorPrefix + this.createAnchorName(type);
+
+        if (autoLink === enums.autoLinkOption.aggressive) {
+            let regExp = new RegExp('([^`\.]|^)' + type + '([ \.]|$)');
+            return string.replace(regExp, "$1" + this.getLinkMarkdown(this.styleCode(type), typeLink) + "$2");
+        }
+        let regExp = new RegExp('`' + type + '`');
+        return string.replace(regExp, this.getLinkMarkdown(this.styleCode(type), typeLink));
+    },
+
+    /**
+    * @function getTOCLink
+    * @param  {string} displayString The text to display in the link.
+    * @param  {string} type          The string to link to.
+    * @return {string} The markdown for a link with displayString text targeted at type.
+    */
+    getTOCLink: function(displayString, type) {
+        if ((!defined(displayString) || displayString.length === 0)) {
+            return displayString;
+        } else if ((!defined(type) || type.length === 0)) {
+            return displayString;
+        }
+        var typeLink = '#' + this.anchorPrefix + this.createAnchorName(type);
+        return this.getLinkMarkdown(this.styleCode(displayString), typeLink);
+    },
+
+    /**
+    * @function getSchemaEmbedLink
+    * @param  {string} displayString The text to display in the link.
+    * @param  {object} schema - The schema for which this section is created
+    * @return {string} The markdown for a link with displayString text targeted at type.
+    */
+    getSchemaEmbedLink: function(displayString, schema) {
+        if ((!defined(displayString) || displayString.length === 0)) {
+            return displayString;
+        } else if (!defined(schema)) {
+            return displayString;
+        }
+
+        var typeName = schema.typeName;
+        if (!defined(typeName)) {
+            typeName = schema.title.toLowerCase().replace(/ /g, ".");
+        }
+
+        var typeLink = '#' + this.anchorSchemaPrefix + this.createAnchorName(typeName);
+        return this.getLinkMarkdown(this.styleCode(displayString), typeLink);
+    },
+
+    embedJsonSchema: function(fileName, schemaRelativeBasePath) {
+        throw new Error("Should be implemented by subclasses");
+    },
+
+    /**
+    * @function bold
+    * Bold the specified string
+    * @param  {string} string - The string to be styled
+    * @return {string} The string styled as bolded for display in markdown.
+    */
+    bold: function(string) { return this.styleBold(string); },
+
+     /**
+     * @function type
+     * Format the type heading for display in markdown
+     * @param  {string} string - The type heading to be styled
+     * @return {string} The type heading styled for display in markdown.
+     */
+     type: function(string) { return this.styleBold(string); },
+ 
+     /**
+     * @function typeValue
+     * Format a typeValue for display in markdown
+     * @param  {string} string - The type value to be styled
+     * @return {string} The typeValue styled for display in markdown.
+     */
+     typeValue: function(string) { return this.styleCode(string); },
+ 
+     /**
+     * @function propertiesSummary
+     * Format the summary of properties for display in markdown
+     * @param  {string} string - The summary of properties to be styled
+     * @return {string} The summary of properties styled for display in markdown.
+     */
+     propertiesSummary: function(string) { return this.styleBold(string); },
+ 
+     /**
+     * @function propertyNameSummary
+     * Format a property name for display in markdown
+     * @param  {string} string - The property name summary to be styled
+     * @return {string} The styled property name summary for display in markdown.
+     */
+     propertyNameSummary: function(string) { return this.styleBold(string); },
+ 
+     /**
+     * @function propertiesDetails
+     * Format the details of properties for display in markdown
+     * @param  {string} string - The details of properties to be styled
+     * @return {string} The details of properties styled for display in markdown.
+     */
+     propertiesDetails: function(string) { return this.styleBold(string); },
+ 
+     /**
+     * @function propertyDetails
+     * Format the details of a property for display in markdown
+     * @param  {string} string - The property details to be styled
+     * @return {string} The property details styled for display in markdown.
+     */
+     propertyDetails: function(string) { return this.styleBold(string); },
+ 
+     /**
+     * @function propertyGltfWebGL
+     * Format a glTF WebGL property for display in markdown
+     * @param  {string} string - The glTF WebGL property to be styled
+     * @return {string} The glTF WebGL property styled for display in markdown.
+     */
+     propertyGltfWebGL: function(string) { return this.styleBold(string); },
+ 
+     /**
+     * @function defaultValue
+     * Format a defaultValue for display in markdown
+     * @param  {string} string - The default value
+     * @param  {type} string - The type of the default value
+     * @return {string} The default value styled for display in markdown.
+     */
+     defaultValue: function(string, type) { return this.styleCodeType(string, type); },
+ 
+     /**
+     * @function enumElement
+     * Format an enumElement for display in markdown
+     * @param  {string} string - The enum element to be styled
+     * @param  {type} string - The type of the enum element
+     * @return {string} The enum element styled for display in markdown.
+     */
+     enumElement: function(string, type) { return this.styleCodeType(string, type); },
+ 
+     /**
+     * @function minMax
+     * Format a minimum or maximum value for display in markdown
+     * @param  {int} value - The minimum/maximum value to be styled
+     * @return {string} The minimum or maximum value styled for display in markdown.
+     */
+     minMax: function(value) { return this.styleMinMax(value); },
+
 };
 
-const REFERENCE = "reference-";
-const SCHEMA_REFERENCE = "schema-reference-";
+module.exports = Style;
 
-/**
- * @private
- */
-function isADoc() {
-    return moduleStyleMode === enums.styleModeOption.AsciiDoctor;
-}
 
-/**
- * @function setStyleMode
- * Set the output style mode: Markdown or AsciiDoctor
- * @param {styleModeOption} mode The desired output style mode.
- */
-function setStyleMode(mode) {
-    moduleStyleMode = mode;
-}
 
-/**
- * @function setCheckmark
- * Set the symbol used to indicate required properties.
- * @param {string} checkmark The desired symbol
- */
-function setCheckmark(checkmark) {
-    if (checkmark.length > 0) {
-        module.exports.requiredIcon = ' ' + checkmark + ' ';
-    } else {
-        module.exports.requiredIcon = '';
-    }
-}
-
-/**
- * @function setMustKeyword
- * Set the keyword used in place of the word "must".
- * @param {string} mustKeyword The keyword used when a condition must be true.
- */
-function setMustKeyword(mustKeyword) {
-    if (mustKeyword.length > 0) {
-        module.exports.mustKeyword = ' ' + mustKeyword + ' ';
-    } else {
-        module.exports.mustKeyword = ' must ';
-    }
-}
-
-/**
-* @function getHeaderMarkdown
-* Gets the markdown syntax for the start of a header.
-* @param  {int} level - The header lever that is being requested
-* @return {string} The markdown string that should be placed prior to the title of the header
-*/
-function getHeaderMarkdown(level) {
-    var md = '';
-    var ch = isADoc() ? '=' : '#';
-    for (var i = 0; i < level; ++i) {
-        md += ch;
-    }
-
-    return md;
-}
-
-/**
-* @function getSectionMarkdown
-* Gets the markdown syntax for the start of a section.
-* @param  {object} schema - The schema for which this section is created
-* @param  {int} level - The header lever that is being requested
-* @param  {boolean} suppressWarnings Indicates if wetzel warnings should be printed in the documentation.
-* @param  {string} embedMode Emum value indicating if we are embedding JSON schema include directives.
-* @return {string} The markdown string that should be placed as the start of the section
-*/
-function getSectionMarkdown(schema, level, suppressWarnings, embedMode) {
-    var md = '';
-
-    if (isADoc()) {
-        // JSON embedded schemas don't get a horizontal rule here, because
-        // there will be page breaks between them instead.
-        if (embedMode !== enums.embedMode.writeIncludeStatements) {
-            md += "'''\n";
-        }
-    } else {
-        md += '---------------------------------------\n';
-    }
-
-    var title = defaultValue(schema.title, suppressWarnings ? '' : 'WETZEL_WARNING: title not defined');
-    var typeName = schema.typeName;
-    if (!defined(typeName)) {
-        typeName = title.toLowerCase().replace(/ /g, ".");
-    }
-
-    var reference = REFERENCE;
-    if (embedMode === enums.embedMode.writeIncludeStatements) {
-        reference = SCHEMA_REFERENCE;
-        title = 'JSON Schema for ' + title;
-    }
-
-    if (isADoc()) {
-        md += '[#' + reference + createAnchorName(typeName) + ']\n';
-    } else {
-        md += '<a name="' + reference + createAnchorName(typeName) + '"></a>\n';
-    }
-    md += getHeaderMarkdown(level) + ' ' + title + '\n\n';
-
-    return md;
-}
-
-/**
-* @function getSectionMarkdown
-* Gets the markdown syntax for a bulleted item.
-* @param  {string} item - The item being bulleted.
-* @param  {int} indentationLevel - The number of indentation levels that should be applied
-* @return {string} The markdown string representing the item as a bulleted item at the proper indentation.
-*/
-function bulletItem(item, indentationLevel) {
-    indentationLevel = defaultValue(indentationLevel, 0);
-    if (isADoc()) {
-        return ('*'.repeat(indentationLevel + 1)) + ' ' + item + '\n';
-    }
-    return (' '.repeat(indentationLevel * 4)) + '* ' + item + '\n';
-}
-
-/**
-* @function getLinkMarkdown
-* Creates a markdown link
-* @param  {string} string - The string to be linked
-* @param  {string} link - The link that should be applied to the string
-* @return {string} The markdown with the specified string hyperlinked to the specified link.
-*/
-function getLinkMarkdown(string, link) {
-    if ((!defined(string) || string.length === 0)) {
-        return '';
-    } else if ((!defined(link) || link.length === 0)) {
-        return string;
-    }
-    if (isADoc()) {
-        if (link[0] === '#') {
-            return '<<' + link.substring(1) + ',' + string + '>>';
-        }
-        return 'link:' + link + '[' + string + ']';
-    }
-    return '[' + string + '](' + link + ')';
-}
-
-/**
- * Creates a table header
- * @param {string} title - The name of this table
- * @param {array} columnList - An array of column names
- */
-function beginTable(title, columnList) {
-    var md = '';
-    if (isADoc()) {
-        md += '.' + title + '\n';
-        md += '|===\n';
-        md += '|' + columnList.join('|') + '\n\n';
-    } else {
-        md += styleBold(title) + '\n\n';
-        md += '|' + columnList.join('|') + '|\n';
-        md += '|---'.repeat(columnList.length) + '|\n';
-    }
-    return md;
-}
-
-/**
- * Adds a row of cells to a table
- * @param {array} data - An array of data for cells on this row.
- */
-function addTableRow(data) {
-    if (isADoc()) {
-        return data.map(d => '|' + d + '\n').join('') + '\n';
-    }
-    return '|' + data.join('|') + '|\n';
-}
-
-/**
- * Ends a table.
- */
-function endTable() {
-    if (isADoc()) {
-        return '|===\n\n';
-    }
-    return '\n';
-}
-
-/**
-* @function styleBold
-* Returns back a markdown string that bolds the provided string.
-* @param  {string} string - The string to be bolded
-* @return {string} The bolded string in markdown syntax
-*/
-function styleBold(string) {
-    if (defined(string) && string.length > 0) {
-        return '**' + string + '**';
-    }
-
-    return '';
-}
-
-/**
-* @function styleCode
-* Returns back a markdown string that displays the provided object as code.
-* @param  {object} code - The object to be displayed as code. It might be a string, or a number, or ...
-* @return {string} The code in markdown code syntax
-*/
-function styleCode(code) {
-    if (defined(code)) {
-        // If it's an object, just serialize it.
-        if (typeof code === 'object') {
-            // Someday may want to use a code fence if it's longer than, say, 88
-            // chars, but that would require keeping track of the current
-            // indentation. Not really how things are designed to work right
-            // now. So add spaces but let it display as a single line for now.
-            return '`' + JSON.stringify(code, null, 1).replace(/\n/g, '').replace(/([{[]) /, '$1') + '`';
-        }
-
-        // The object might be a string or it might be a number or something else.
-        // Let's make sure it's a string first.
-        var stringified = code.toString();
-
-        if (stringified.length > 0) {
-            return '`' + stringified + '`';
-        }
-    }
-
-    return '';
-}
-
-/**
-* @function styleMinMax
-* Returns back a markdown string that displays the provided min/max values as code.
-* @param  {object} code - The object to be displayed as min/max code. It might be a string, or a number, or ...
-* @return {string} The code in markdown code syntax
-*/
-function styleMinMax(code) {
-    if (defined(code)) {
-        // The object might be a string or it might be a number or something else.
-        // Let's make sure it's a string first.
-        var stringified = code.toString();
-
-        if (stringified.length > 0) {
-            if (isADoc()) {
-                stringified = stringified.replace(/</g, '&lt;');
-                stringified = stringified.replace(/>/g, '&gt;');
-                stringified = stringified.trim();
-            }
-            return styleCode(stringified);
-        }
-    }
-
-    return '';
-}
-
-/**
-* @function styleCodeType
-* Returns back a markdown string that displays the provided string as code.
-* @param  {string} string - The string to be displayed as code
-* @param  {string} type - The type of the content in string (if it's a literal string, it will be formatted differently)
-* @return {string} The string in markdown code syntax
-*/
-function styleCodeType(string, type) {
-    if (!defined(string) || string.length === 0) {
-        return '';
-    } else if (type === 'string') {
-        return styleCode('"' + string + '"');
-    }
-
-    return styleCode(string);
-}
-
-/**
- * Convert the given string into the string that will be used for
- * the anchors that serve as link targets in the resulting MD.
- *
- * @param {string} string The string
- * @return {string} The anchor name
- */
-function createAnchorName(string) {
-    return string.toLowerCase()
-        .replace(/ /g, "-")
-        .replace(/\./g, "-");
-}
-
-/**
-* @function linkType
-* Finds any occurrence of type in the provided string, and adds a markdown link to it.
-* @param  {string} string - The string that might be referencing a type
-* @param  {string} type - The type whose reference within string should be linked.
-* @param  {string} autoLink - The enum value indicating how the auto-linking should be handled.
-* @return {string} The updated string, with any occurrences of the @type string linked via markdown.
-*/
-function linkType(string, type, autoLink) {
-    if (defaultValue(autoLink, enums.autoLinkOption.off) === enums.autoLinkOption.off) {
-        return string;
-    } else if ((!defined(string) || string.length === 0)) {
-        return string;
-    } else if ((!defined(type) || type.length === 0)) {
-        return string;
-    }
-    if (type === 'integer' || type === 'string' ||
-        type === 'object'  || type === 'number' ||
-        type === 'boolean') {
-        return string;
-    }
-    var typeLink = '#' + REFERENCE + createAnchorName(type);
-
-    if (autoLink === enums.autoLinkOption.aggressive) {
-        let regExp = new RegExp('([^`\.]|^)' + type + '([ \.]|$)');
-        return string.replace(regExp, "$1" + getLinkMarkdown(styleCode(type), typeLink) + "$2");
-    }
-    let regExp = new RegExp('`' + type + '`');
-    return string.replace(regExp, getLinkMarkdown(styleCode(type), typeLink));
-}
-
-/**
-* @function getTOCLink
-* @param  {string} displayString The text to display in the link.
-* @param  {string} type          The string to link to.
-* @return {string} The markdown for a link with displayString text targeted at type.
-*/
-function getTOCLink(displayString, type) {
-    if ((!defined(displayString) || displayString.length === 0)) {
-        return displayString;
-    } else if ((!defined(type) || type.length === 0)) {
-        return displayString;
-    }
-    var typeLink = '#' + REFERENCE + createAnchorName(type);
-    return getLinkMarkdown(styleCode(displayString), typeLink);
-}
-
-/**
-* @function getSchemaEmbedLink
-* @param  {string} displayString The text to display in the link.
-* @param  {object} schema - The schema for which this section is created
-* @return {string} The markdown for a link with displayString text targeted at type.
-*/
-function getSchemaEmbedLink(displayString, schema) {
-    if ((!defined(displayString) || displayString.length === 0)) {
-        return displayString;
-    } else if (!defined(schema)) {
-        return displayString;
-    }
-
-    var typeName = schema.typeName;
-    if (!defined(typeName)) {
-        typeName = schema.title.toLowerCase().replace(/ /g, ".");
-    }
-
-    var typeLink = '#' + SCHEMA_REFERENCE + createAnchorName(typeName);
-    return getLinkMarkdown(styleCode(displayString), typeLink);
-}
-
-function embedJsonSchema(fileName, schemaRelativeBasePath) {
-    var md = '';
-    if (!defined(schemaRelativeBasePath)) {
-        schemaRelativeBasePath = '';
-    } else if (!schemaRelativeBasePath.endsWith('/')) {
-        schemaRelativeBasePath += '/';
-    }
-
-    if (isADoc()) {
-        md += '[source,json]\n';
-        md += '----\n';
-        md += 'include::' + schemaRelativeBasePath + fileName + '[]\n';
-        md += '----\n\n';
-        md += "<<<\n";  // Page break between embedded JSON schema files
-    } else {
-        md += getLinkMarkdown(fileName, schemaRelativeBasePath + fileName) + '\n';
-    }
-    return md;
-}

--- a/lib/styleAdoc.js
+++ b/lib/styleAdoc.js
@@ -1,0 +1,113 @@
+"use strict";
+var defined = require('./defined');
+var defaultValue = require('./defaultValue');
+var enums = require('./enums');
+var Style = require('./style');
+
+const StyleAdoc = function(){};
+
+StyleAdoc.prototype = Object.create(Style);
+
+StyleAdoc.prototype.getHeaderMarkdown = function(level) {
+    var md = '';
+    var ch = '=';
+    for (var i = 0; i < level; ++i) {
+        md += ch;
+    }
+    return md;
+};
+
+StyleAdoc.prototype.getSectionMarkdown = function(schema, level, suppressWarnings, embedMode) {
+    var md = '';
+
+    // JSON embedded schemas don't get a horizontal rule here, because
+    // there will be page breaks between them instead.
+    if (embedMode !== enums.embedMode.writeIncludeStatements) {
+        md += "'''\n";
+    }
+
+    var title = defaultValue(schema.title, suppressWarnings ? '' : 'WETZEL_WARNING: title not defined');
+    var typeName = schema.typeName;
+    if (!defined(typeName)) {
+        typeName = title.toLowerCase().replace(/ /g, ".");
+    }
+
+    var reference = this.anchorPrefix;
+    if (embedMode === enums.embedMode.writeIncludeStatements) {
+        reference = this.anchorSchemaPrefix;
+        title = 'JSON Schema for ' + title;
+    }
+
+    md += '[#' + reference + this.createAnchorName(typeName) + ']\n';
+    md += this.getHeaderMarkdown(level) + ' ' + title + '\n\n';
+
+    return md;
+};
+
+StyleAdoc.prototype.bulletItem = function(item, indentationLevel) {
+    indentationLevel = defaultValue(indentationLevel, 0);
+    return ('*'.repeat(indentationLevel + 1)) + ' ' + item + '\n';
+};
+
+StyleAdoc.prototype.getLinkMarkdown = function(string, link) {
+    if ((!defined(string) || string.length === 0)) {
+        return '';
+    } else if ((!defined(link) || link.length === 0)) {
+        return string;
+    }
+    if (link[0] === '#') {
+        return '<<' + link.substring(1) + ',' + string + '>>';
+    }
+    return 'link:' + link + '[' + string + ']';
+};
+
+StyleAdoc.prototype.beginTable = function(title, columnList) {
+    var md = '';
+    md += '.' + title + '\n';
+    md += '|===\n';
+    md += '|' + columnList.join('|') + '\n\n';
+    return md;
+};
+
+StyleAdoc.prototype.addTableRow = function(data) {
+    return data.map(d => '|' + d + '\n').join('') + '\n';
+};
+
+StyleAdoc.prototype.endTable = function() {
+    return '|===\n\n';
+};
+
+StyleAdoc.prototype.styleMinMax = function(code) {
+    if (defined(code)) {
+        // The object might be a string or it might be a number or something else.
+        // Let's make sure it's a string first.
+        var stringified = code.toString();
+
+        if (stringified.length > 0) {
+            stringified = stringified.replace(/</g, '&lt;');
+            stringified = stringified.replace(/>/g, '&gt;');
+            stringified = stringified.trim();
+            return this.styleCode(stringified);
+        }
+    }
+    return '';
+};
+
+StyleAdoc.prototype.embedJsonSchema = function(fileName, schemaRelativeBasePath) {
+    var md = '';
+    if (!defined(schemaRelativeBasePath)) {
+        schemaRelativeBasePath = '';
+    } else if (!schemaRelativeBasePath.endsWith('/')) {
+        schemaRelativeBasePath += '/';
+    }
+
+    md += '[source,json]\n';
+    md += '----\n';
+    md += 'include::' + schemaRelativeBasePath + fileName + '[]\n';
+    md += '----\n\n';
+    md += "<<<\n";  // Page break between embedded JSON schema files
+
+    return md;
+};
+
+module.exports = StyleAdoc;

--- a/lib/styleMd.js
+++ b/lib/styleMd.js
@@ -1,0 +1,97 @@
+"use strict";
+var defined = require('./defined');
+var defaultValue = require('./defaultValue');
+var enums = require('./enums');
+var Style = require('./style');
+
+const StyleMd = function(){};
+
+StyleMd.prototype = Object.create(Style);
+
+StyleMd.prototype.getHeaderMarkdown = function(level) {
+    var md = '';
+    var ch = '#';
+    for (var i = 0; i < level; ++i) {
+        md += ch;
+    }
+    return md;
+};
+
+StyleMd.prototype.getSectionMarkdown = function(schema, level, suppressWarnings, embedMode) {
+    var md = '';
+    md += '---------------------------------------\n';
+
+    var title = defaultValue(schema.title, suppressWarnings ? '' : 'WETZEL_WARNING: title not defined');
+    var typeName = schema.typeName;
+    if (!defined(typeName)) {
+        typeName = title.toLowerCase().replace(/ /g, ".");
+    }
+
+    var reference = this.anchorPrefix;
+    if (embedMode === enums.embedMode.writeIncludeStatements) {
+        reference = this.anchorSchemaPrefix;
+        title = 'JSON Schema for ' + title;
+    }
+
+    md += '<a name="' + reference + this.createAnchorName(typeName) + '"></a>\n';
+    md += this.getHeaderMarkdown(level) + ' ' + title + '\n\n';
+
+    return md;
+};
+
+StyleMd.prototype.bulletItem = function(item, indentationLevel) {
+    indentationLevel = defaultValue(indentationLevel, 0);
+    return (' '.repeat(indentationLevel * 4)) + '* ' + item + '\n';
+};
+
+StyleMd.prototype.getLinkMarkdown = function(string, link) {
+    if ((!defined(string) || string.length === 0)) {
+        return '';
+    } else if ((!defined(link) || link.length === 0)) {
+        return string;
+    }
+    return '[' + string + '](' + link + ')';
+};
+
+StyleMd.prototype.beginTable = function(title, columnList) {
+    var md = '';
+    md += this.styleBold(title) + '\n\n';
+    md += '|' + columnList.join('|') + '|\n';
+    md += '|---'.repeat(columnList.length) + '|\n';
+    return md;
+};
+
+StyleMd.prototype.addTableRow = function(data) {
+    return '|' + data.join('|') + '|\n';
+};
+
+StyleMd.prototype.endTable = function() {
+    return '\n';
+};
+
+StyleMd.prototype.styleMinMax = function(code) {
+    if (defined(code)) {
+        // The object might be a string or it might be a number or something else.
+        // Let's make sure it's a string first.
+        var stringified = code.toString();
+
+        if (stringified.length > 0) {
+            return this.styleCode(stringified);
+        }
+    }
+    return '';
+};
+
+StyleMd.prototype.embedJsonSchema = function(fileName, schemaRelativeBasePath) {
+    var md = '';
+    if (!defined(schemaRelativeBasePath)) {
+        schemaRelativeBasePath = '';
+    } else if (!schemaRelativeBasePath.endsWith('/')) {
+        schemaRelativeBasePath += '/';
+    }
+    md += this.getLinkMarkdown(fileName, schemaRelativeBasePath + fileName) + '\n';
+    return md;
+};
+
+module.exports = StyleMd;
+


### PR DESCRIPTION
The [`style`](https://github.com/CesiumGS/wetzel/blob/189f3f893e09dee3fb4f74edcf7fd4cbcb86bc8a/lib/style.js) currently is a set of functions that serve the purpose of formatting/styling the output. A considerable number of functions use some [`if (isAdoc())` check](https://github.com/CesiumGS/wetzel/blob/189f3f893e09dee3fb4f74edcf7fd4cbcb86bc8a/lib/style.js#L252) to generate different outputs, depending on whether the output should be Markdown or AsciiDoc, and this is [configured where the style is initialized based on the command line parameters](https://github.com/CesiumGS/wetzel/blob/189f3f893e09dee3fb4f74edcf7fd4cbcb86bc8a/lib/generateMarkdown.js#L27).

It might be a matter of ... style (...), but when I see a structure like
```
boolean flag;
function functionA() { if (flag) doThis(); else doThat(); }
function functionB() { if (flag) doThis(); else doThat(); }
function functionC() { if (flag) doThis(); else doThat(); }
...
``` 
then this just screams "interface" to me. 

This is a draft of converting `style` into such an interface/abstract base class, with specific implementations `styleMd` and `styleAdoc`. 

One could consider going further with that, in a larger refactoring, and turning the current `style` into something like a "generator backend" that just receives the respective parts of the schema, and generates output. This might be generalized so that it could create everything between a single MD file or a set of HTML files, transparently. This would imply defining the best interface for this "backend", and right now, there are things in the `generateMarkdown.js` that could reasonably be part of such a more generic backend. But I wanted to create this **DRAFT** PR to gather feedback of whether any efforts in this direction are worth pursuing. 

---
Edit:

One technical detail that is related to this: There are currently some [hard-wired prefixes](https://github.com/CesiumGS/wetzel/blob/189f3f893e09dee3fb4f74edcf7fd4cbcb86bc8a/lib/style.js#L138) for the `#anchor` names that are generated. This could or should be configurable for the case that multiple property references (with possibly duplicate names) are supposed to be merged into one larger document.


