### PR TITLE
Update dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
         "lib": "./lib"
     },
     "dependencies": {
-        "jsonpointer": "^4.1.0",
-        "minimist": "1.1.0"
+        "jsonpointer": "^5.0.0",
+        "minimist": "^1.2.6"
     },
     "devDependencies": {
         "eslint": "^7.10.0",
-        "mocha": "^8.2.1"
+        "mocha": "^10.0.0"
     },
     "bin": {
         "wetzel": "./bin/wetzel.js"


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/wetzel/issues/66 

Also updates mocha to the latest version. 

The tests still pass. If there are further steps to verify any form of compatibility before merging this, just drop me a note.

