### PR TITLE
Extract mergeProperties

### DIFF
--- a/lib/mergeProperties.js
+++ b/lib/mergeProperties.js
@@ -1,0 +1,51 @@
+"use strict";
+var defined = require('./defined');
+var clone = require('./clone');
+var defaultValue = require('./defaultValue');
+
+module.exports = mergeProperties;
+
+/**
+* @function mergeProperties
+* Recusively takes properties within a schema reference ("the base") and merges the contents of
+* those properties into the derived schema.
+* @param  {object} derived - The schema that contains a reference to the 'base' schema.
+* @param  {object} base - The schema that was being referenced by 'derived'.
+* @return {object} The merged schema with the 'base' schema reference removed since the contents
+* have been merged into 'derived'.
+*/
+function mergeProperties(derived, base) {
+    for (let name in base) {
+        if (base.hasOwnProperty(name)) {
+            let baseProperty = base[name];
+
+            // Inherit from the base schema.  The derived joins existing values if it has the same property.
+            if (typeof baseProperty === 'object') {
+                if (Array.isArray(baseProperty)) {
+                    derived[name] = defaultValue(derived[name], []);
+                    let cloned = clone(baseProperty, true);
+                    derived[name] = derived[name].concat(cloned);
+                } else {
+                    derived[name] = defaultValue(derived[name], {});
+                    let derivedProperty = derived[name];
+
+                    for (let n in baseProperty) {
+                        let cloned = clone(baseProperty[n], true);
+                        if (baseProperty.hasOwnProperty(n)) {
+                            if (defined(derivedProperty[n])) {
+                                derivedProperty[n] = Object.assign(derivedProperty[n], cloned);
+                            } else {
+                                derivedProperty[n] = cloned;
+                            }
+                        }
+                    }
+                }
+            } else if (name !== 'typeName' || derived.title === base.title) {
+                let cloned = clone(baseProperty, true);
+                if (!defined(derived[name])) {
+                    derived[name] = cloned;
+                }
+            }
+        }
+    }
+}

--- a/lib/schema3Resolver.js
+++ b/lib/schema3Resolver.js
@@ -1,7 +1,7 @@
 "use strict";
 var fs = require('fs');
 var defined = require('./defined');
-var defaultValue = require('./defaultValue');
+var mergeProperties = require('./mergeProperties');
 var clone = require('./clone');
 var replaceRef = require('./replaceRef');
 
@@ -72,9 +72,14 @@ function extend(derived) {
     var base = derived['extends'];
     if (defined(base)) {
         delete derived['extends'];
-        // TODO: extends could be an array
-        mergeProperties(derived, base);
-
+        
+        if (Array.isArray(base)) {
+            for (var singleBase in base) {
+                mergeProperties(derived, base[singleBase]);
+            }
+        } else  {
+            mergeProperties(derived, base);
+        }
         extend(derived);
     }
 
@@ -87,35 +92,3 @@ function extend(derived) {
     }
 }
 
-/**
-* @function mergeProperties
-* Recusively takes properties within a schema reference ("the base") and merges the contents of
-* those properties into the derived schema.
-* @param  {object} derived - The schema that contains a reference to the 'base' schema.
-* @param  {object} base - The schema that was being referenced by 'derived'.
-* @return {object} The merged schema with the 'base' schema reference removed since the contents
-* have been merged into 'derived'.
-*/
-function mergeProperties(derived, base) {
-    for (var name in base) {
-        if (base.hasOwnProperty(name)) {
-            var baseProperty = base[name];
-
-            // Inherit from the base schema.  The derived schema overrides if it has the same property.
-            if (typeof baseProperty === 'object') {
-                derived[name] = defaultValue(derived[name], {});
-                var derivedProperty = derived[name];
-
-                for (var n in baseProperty) {
-                    if (baseProperty.hasOwnProperty(n)) {
-                        if (!defined(derivedProperty[n])) {
-                            derivedProperty[n] = clone(baseProperty[n], true);
-                        }
-                    }
-                }
-            } else if (!defined(derived[name])) {
-                derived[name] = clone(baseProperty, true);
-            }
-        }
-    }
-}

--- a/lib/schema4Resolver.js
+++ b/lib/schema4Resolver.js
@@ -1,7 +1,7 @@
 "use strict";
 var fs = require('fs');
 var defined = require('./defined');
-var defaultValue = require('./defaultValue');
+var mergeProperties = require('./mergeProperties');
 var clone = require('./clone');
 var replaceRef = require('./replaceRef');
 
@@ -92,51 +92,6 @@ function resolveInheritance(derived) {
         if (derived.hasOwnProperty(name)) {
             if (typeof derived[name] === 'object') {
                 resolveInheritance(derived[name]);
-            }
-        }
-    }
-}
-
-/**
-* @function mergeProperties
-* Recusively takes properties within a schema reference ("the base") and merges the contents of
-* those properties into the derived schema.
-* @param  {object} derived - The schema that contains a reference to the 'base' schema.
-* @param  {object} base - The schema that was being referenced by 'derived'.
-* @return {object} The merged schema with the 'base' schema reference removed since the contents
-* have been merged into 'derived'.
-*/
-function mergeProperties(derived, base) {
-    for (let name in base) {
-        if (base.hasOwnProperty(name)) {
-            let baseProperty = base[name];
-
-            // Inherit from the base schema.  The derived joins existing values if it has the same property.
-            if (typeof baseProperty === 'object') {
-                if (Array.isArray(baseProperty)) {
-                    derived[name] = defaultValue(derived[name], []);
-                    let cloned = clone(baseProperty, true);
-                    derived[name] = derived[name].concat(cloned);
-                } else {
-                    derived[name] = defaultValue(derived[name], {});
-                    let derivedProperty = derived[name];
-
-                    for (let n in baseProperty) {
-                        let cloned = clone(baseProperty[n], true);
-                        if (baseProperty.hasOwnProperty(n)) {
-                            if (defined(derivedProperty[n])) {
-                                derivedProperty[n] = Object.assign(derivedProperty[n], cloned);
-                            } else {
-                                derivedProperty[n] = cloned;
-                            }
-                        }
-                    }
-                }
-            } else if (name !== 'typeName' || derived.title === base.title) {
-                let cloned = clone(baseProperty, true);
-                if (!defined(derived[name])) {
-                    derived[name] = cloned;
-                }
             }
         }
     }


### PR DESCRIPTION
In the attempt to make some small, non-breaking, "isolated" <strike>changes</strike> improvements: The `mergeProperties` function had been duplicated in `schema3Resolver.js` and `schema4Resolver.js`, with some small differences. I have **not** analyzed the exact differences, but assume that they have to do with the [`// TODO: extends could be an array`](https://github.com/CesiumGS/wetzel/blob/f3038a8df68d2dd35c243ae158786e645b508bc6/lib/schema3Resolver.js#L75) in `schema3Resolver.js`, and tried to handle this accordingly.

Schema version 03 is probably hardly used any more, so I think that even in the worst case, this change should be not so critical. But the tests (of which some **do** include 03 schemas) still pass. 

