### PR TITLE
Add ThirdParty.json

### DIFF
--- a/ThirdParty.json
+++ b/ThirdParty.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "jsonpointer",
+    "license": [
+      "MIT"
+    ],
+    "version": "5.0.0",
+    "url": "https://www.npmjs.com/package/jsonpointer"
+  },
+  {
+    "name": "minimist",
+    "license": [
+      "MIT"
+    ],
+    "version": "1.2.6",
+    "url": "https://www.npmjs.com/package/minimist"
+  }
+]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,89 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+module.exports = {
+  "generate-third-party": generateThirdParty,
+};
+
+function getLicenseDataFromPackage(packageName, override) {
+  override = override || {};
+  const packagePath = path.join("node_modules", packageName, "package.json");
+
+  if (!fs.existsSync(packagePath)) {
+    throw new Error(`Unable to find ${packageName} license information`);
+  }
+
+  const contents = fs.readFileSync(packagePath);
+  const packageJson = JSON.parse(contents);
+
+  let licenseField = override.license;
+
+  if (!licenseField) {
+    licenseField = [packageJson.license];
+  }
+
+  if (!licenseField && packageJson.licenses) {
+    licenseField = packageJson.licenses;
+  }
+
+  if (!licenseField) {
+    console.log(`No license found for ${packageName}`);
+    licenseField = ["NONE"];
+  }
+
+  let version = packageJson.version;
+  if (!packageJson.version) {
+    console.log(`No version information found for ${packageName}`);
+    version = "NONE";
+  }
+
+  return {
+    name: packageName,
+    license: licenseField,
+    version: version,
+    url: `https://www.npmjs.com/package/${packageName}`,
+    notes: override.notes,
+  };
+}
+
+function readThirdPartyExtraJson() {
+  const path = "ThirdParty.extra.json";
+  if (fs.existsSync(path)) {
+    const contents = fs.readFileSync(path);
+    return JSON.parse(contents);
+  }
+  return [];
+}
+
+async function generateThirdParty() {
+  const packageJson = JSON.parse(fs.readFileSync("package.json"));
+  const thirdPartyExtraJson = readThirdPartyExtraJson();
+
+  const thirdPartyJson = [];
+
+  const dependencies = packageJson.dependencies;
+  for (const packageName in dependencies) {
+    if (dependencies.hasOwnProperty(packageName)) {
+      const override = thirdPartyExtraJson.find(
+        (entry) => entry.name === packageName
+      );
+      thirdPartyJson.push(getLicenseDataFromPackage(packageName, override));
+    }
+  }
+
+  thirdPartyJson.sort(function (a, b) {
+    const nameA = a.name.toLowerCase();
+    const nameB = b.name.toLowerCase();
+    if (nameA < nameB) {
+      return -1;
+    }
+    if (nameA > nameB) {
+      return 1;
+    }
+    return 0;
+  });
+
+  fs.writeFileSync("ThirdParty.json", JSON.stringify(thirdPartyJson, null, 2));
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     },
     "devDependencies": {
         "eslint": "^7.10.0",
+        "gulp": "^4.0.2",
         "mocha": "^10.0.0"
     },
     "bin": {
@@ -38,6 +39,7 @@
     },
     "scripts": {
         "test": "mocha",
-        "test-bail": "mocha -b"
+        "test-bail": "mocha -b",
+        "generate-third-party": "gulp generate-third-party"
     }
 }


### PR DESCRIPTION
Adds `ThirdParty.json` for tracking third party dependencies. To regenerate the file run `npm run generate-third-party`.

CC @shehzan10 