### PR TITLE
Extensions property type fix

### DIFF
--- a/lib/generateMarkdown.js
+++ b/lib/generateMarkdown.js
@@ -400,8 +400,8 @@ function createPropertiesDetails(schema, title, headerLevel, knownTypes, autoLin
                 if (defined(additionalPropertiesType)) {
                     // TODO: additionalProperties is really a full schema
                     var formattedType = style.typeValue(additionalPropertiesType);
-                    if ((additionalProperties.type === 'object') && defined(property.title)) {
-                        formattedType = style.linkType(property.title, property.title, autoLink);
+                    if ((additionalProperties.type === 'object') && defined(additionalProperties.title)) {
+                        formattedType = style.linkType(additionalProperties.title, additionalProperties.title, autoLink);
                     }
 
                     md += style.bulletItem(style.propertyDetails('Type of each property') + ': ' + formattedType, 0);

--- a/test/test-golden/nested-embed.adoc
+++ b/test/test-golden/nested-embed.adoc
@@ -101,7 +101,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 === bufferView.extras
 
@@ -235,7 +235,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 === image.extras
 
@@ -316,7 +316,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 === material.extras
 
@@ -442,7 +442,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 === material.pbrMetallicRoughness.extras
 
@@ -548,7 +548,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 === nestedTest.extras
 

--- a/test/test-golden/nested-keyword.md
+++ b/test/test-golden/nested-keyword.md
@@ -78,7 +78,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ### bufferView.extras
 
@@ -179,7 +179,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ### image.extras
 
@@ -225,7 +225,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ### material.extras
 
@@ -328,7 +328,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ### material.pbrMetallicRoughness.extras
 
@@ -403,7 +403,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ### nestedTest.extras
 

--- a/test/test-golden/nested-linked.adoc
+++ b/test/test-golden/nested-linked.adoc
@@ -109,7 +109,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ==== bufferView.extras
 
@@ -243,7 +243,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ==== image.extras
 
@@ -324,7 +324,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ==== material.extras
 
@@ -450,7 +450,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ==== material.pbrMetallicRoughness.extras
 
@@ -556,7 +556,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ==== nestedTest.extras
 

--- a/test/test-golden/nested-linked.md
+++ b/test/test-golden/nested-linked.md
@@ -80,7 +80,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 #### bufferView.extras
 
@@ -185,7 +185,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 #### image.extras
 
@@ -233,7 +233,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 #### material.extras
 
@@ -338,7 +338,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 #### material.pbrMetallicRoughness.extras
 
@@ -415,7 +415,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 #### nestedTest.extras
 

--- a/test/test-golden/nested-remote.adoc
+++ b/test/test-golden/nested-remote.adoc
@@ -101,7 +101,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 === bufferView.extras
 
@@ -235,7 +235,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 === image.extras
 
@@ -316,7 +316,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 === material.extras
 
@@ -442,7 +442,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 === material.pbrMetallicRoughness.extras
 
@@ -548,7 +548,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: <<reference-extension,`extension`>>
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 === nestedTest.extras
 

--- a/test/test-golden/nested-remote.md
+++ b/test/test-golden/nested-remote.md
@@ -72,7 +72,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ### bufferView.extras
 
@@ -177,7 +177,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ### image.extras
 
@@ -225,7 +225,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ### material.extras
 
@@ -330,7 +330,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ### material.pbrMetallicRoughness.extras
 
@@ -407,7 +407,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: [`extension`](#reference-extension)
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ### nestedTest.extras
 

--- a/test/test-golden/nested-simple.adoc
+++ b/test/test-golden/nested-simple.adoc
@@ -107,7 +107,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 === bufferView.extras
 
@@ -237,7 +237,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 === image.extras
 
@@ -316,7 +316,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 === material.extras
 
@@ -440,7 +440,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 === material.pbrMetallicRoughness.extras
 
@@ -544,7 +544,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 === nestedTest.extras
 

--- a/test/test-golden/nested-simple.md
+++ b/test/test-golden/nested-simple.md
@@ -78,7 +78,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ### bufferView.extras
 
@@ -179,7 +179,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ### image.extras
 
@@ -225,7 +225,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ### material.extras
 
@@ -328,7 +328,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ### material.pbrMetallicRoughness.extras
 
@@ -403,7 +403,7 @@ Dictionary object with extension-specific objects.
 
 * **Type**: `extension`
 * **Required**: No
-* **Type of each property**: Extension
+* **Type of each property**: `object`
 
 ### nestedTest.extras
 


### PR DESCRIPTION
This was brought up in https://github.com/CesiumGS/wetzel/pull/68#discussion_r824755241 and confirmed to be an issue in the generated output via https://github.com/KhronosGroup/glTF/issues/2158#issuecomment-1126772493 

The change in this PR is supposed to be ~"the smallest possible change that should cause the right output to be generated for glTF". 

(This will cause merge conflicts with some other open/pending PRs, but they should be small and very local. The exact strategy that is used for auto-linking is a bit non-trivial. Whether the current solution works for `additionalProperties` that are _not_ only "object" would have to be examined with dedicated tests, but this should not be relevant for glTF)

